### PR TITLE
Fix index and add mode flag for bootstrap

### DIFF
--- a/blockwork/activities/bootstrap.py
+++ b/blockwork/activities/bootstrap.py
@@ -22,10 +22,10 @@ from ..context import Context
 @click.option("--mode",
             type=click.Choice(BwBootstrapMode, case_sensitive=False),
             default="default",
-            help=f"""Set the bootstrap mode. 
+            help="""Set the bootstrap mode. 
                         default: Rebuild out of date steps
                         force: Rebuild all steps
-                    """)
+                 """)
 @click.pass_obj
 def bootstrap(ctx : Context, mode: str) -> None:
     """ Run all bootstrapping actions """

--- a/blockwork/activities/bootstrap.py
+++ b/blockwork/activities/bootstrap.py
@@ -15,25 +15,17 @@
 import logging
 
 import click
-from click.core import Command, Option
-
 from ..bootstrap import Bootstrap, BwBootstrapMode
 from ..context import Context
 
-class BwBootstrapCommand(Command):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.params.insert(0,
-                            Option(("--mode", ),
-                            type=click.Choice(BwBootstrapMode._member_names_, case_sensitive=False),
-                            default="default",
-                            help=f"""Set the bootstrap mode. 
-                                     default: Rebuild out of date steps
-                                     force: Rebuild all steps
-                                  """))
-
-
-@click.command(cls=BwBootstrapCommand)
+@click.command()
+@click.option("--mode",
+            type=click.Choice(BwBootstrapMode, case_sensitive=False),
+            default="default",
+            help=f"""Set the bootstrap mode. 
+                        default: Rebuild out of date steps
+                        force: Rebuild all steps
+                    """)
 @click.pass_obj
 def bootstrap(ctx : Context, mode: str) -> None:
     """ Run all bootstrapping actions """

--- a/blockwork/activities/bootstrap.py
+++ b/blockwork/activities/bootstrap.py
@@ -15,6 +15,7 @@
 import logging
 
 import click
+
 from ..bootstrap import Bootstrap, BwBootstrapMode
 from ..context import Context
 

--- a/blockwork/bootstrap/__init__.py
+++ b/blockwork/bootstrap/__init__.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 # Bootstrap infrastructure
-from .registry import Bootstrap, BootstrapStep
+from .registry import Bootstrap, BootstrapStep, BwBootstrapMode
 
 # Built-in bootstrapping rules
 from .containers import build_foundation
 
 # Lint guards
-assert all((Bootstrap, BootstrapStep))
+assert all((Bootstrap, BootstrapStep, BwBootstrapMode))
 assert all((build_foundation, ))

--- a/blockwork/bootstrap/registry.py
+++ b/blockwork/bootstrap/registry.py
@@ -97,10 +97,10 @@ class Bootstrap:
         """
         tracking = context.state.bootstrap
         for step in cls.REGISTERED.values():
-            raw      = tracking.get(step.id, 0)
             if mode == BwBootstrapMode.force:
                 last_run = datetime.min
             else:
+                raw      = tracking.get(step.id, 0)
                 last_run = datetime.fromisoformat(raw) if raw else datetime.min
             if step.check_point:
                 chk_point = context.host_root / step.check_point

--- a/blockwork/bootstrap/registry.py
+++ b/blockwork/bootstrap/registry.py
@@ -19,7 +19,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
-from enum import Enum, unique
+from enum import StrEnum, auto
 
 from ..context import Context
 
@@ -33,11 +33,10 @@ class BootstrapStep:
     def id(self) -> str:
         return self.full_path.replace(".", "__")
 
-@unique
-class BwBootstrapMode(Enum):
-    default = 1
+class BwBootstrapMode(StrEnum):
+    default = auto()
     'Default behaviour'
-    force = 2
+    force = auto()
     'Rerun steps even when they are in-date'
 
 class Bootstrap:

--- a/blockwork/bootstrap/registry.py
+++ b/blockwork/bootstrap/registry.py
@@ -19,6 +19,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
+from enum import Enum, unique
 
 from ..context import Context
 
@@ -32,6 +33,12 @@ class BootstrapStep:
     def id(self) -> str:
         return self.full_path.replace(".", "__")
 
+@unique
+class BwBootstrapMode(Enum):
+    default = 1
+    'Default behaviour'
+    force = 2
+    'Rerun steps even when they are in-date'
 
 class Bootstrap:
     """ Collects bootstrapping routines together """
@@ -82,7 +89,7 @@ class Bootstrap:
         return _inner
 
     @classmethod
-    def invoke(cls, context : Context) -> None:
+    def invoke(cls, context : Context, mode : BwBootstrapMode = BwBootstrapMode.default) -> None:
         """
         Evaluate all of the registered bootstrap methods, checking to see whether
         they are out-of-date based on their 'check_point' before executing them.
@@ -92,7 +99,10 @@ class Bootstrap:
         tracking = context.state.bootstrap
         for step in cls.REGISTERED.values():
             raw      = tracking.get(step.id, 0)
-            last_run = datetime.fromisoformat(raw) if raw else datetime.min
+            if mode == BwBootstrapMode.force:
+                last_run = datetime.min
+            else:
+                last_run = datetime.fromisoformat(raw) if raw else datetime.min
             if step.check_point:
                 chk_point = context.host_root / step.check_point
                 if (chk_point.exists() and

--- a/example/infra/bootstrap/tools.py
+++ b/example/infra/bootstrap/tools.py
@@ -25,12 +25,12 @@ def download_tools(context : Context, last_run : datetime) -> bool:
     with tempfile.TemporaryDirectory() as tmpdir:
         for idx, (rel_path, url) in enumerate(data.items()):
             if (tool_base / rel_path).exists():
-                logging.info(f"[{idx:2d} / {len(data.keys()):2d}] Skipping as {rel_path} already exists")
+                logging.info(f"[{idx+1:2d} / {len(data.keys()):2d}] Skipping as {rel_path} already exists")
                 continue
             local = Path(tmpdir) / f"tool_{idx}.zip"
-            logging.info(f"[{idx:2d} / {len(data.keys()):2d}] Downloading {rel_path} from {url}")
+            logging.info(f"[{idx+1:2d} / {len(data.keys()):2d}] Downloading {rel_path} from {url}")
             request.urlretrieve(url, local)
-            logging.info(f"[{idx:2d} / {len(data.keys()):2d}] Unzipping {rel_path} into {tool_base}")
+            logging.info(f"[{idx+1:2d} / {len(data.keys()):2d}] Unzipping {rel_path} into {tool_base}")
             with zipfile.ZipFile(local, "r") as zh:
                 for info in zh.infolist():
                     _extract(zh, info, tool_base)


### PR DESCRIPTION
Fix indexing of bootstrap steps.
Add a bootstrap `mode` argument to allow forced rebuilds.
This was made a choice rather than a flag so that we can add more modes later, e.g. dryrun perhaps
