### PR TITLE
escape unicode errors and fix lack of carraige returns

### DIFF
--- a/blockwork/containers/common.py
+++ b/blockwork/containers/common.py
@@ -75,12 +75,12 @@ def read_stream(socket : SocketIO, e_done : Event) -> Thread:
                 rlist, _, _ = select.select([socket], [], [], 0.1)
                 if rlist:
                     buff = socket.read(1024)
+                    # @edwardk: Not entirely sure why this replace is necessary
+                    # but otherwise we don't get carriage returns
+                    buff = buff.replace(b'\n',b'\r\n')
                     if len(buff) > 0:
-                        try:
-                            sys.stdout.write(buff.decode("utf-8"))
-                            sys.stdout.flush()
-                        except UnicodeDecodeError:
-                            pass
+                        sys.stdout.write(buff.decode("utf-8", errors='backslashreplace'))
+                        sys.stdout.flush()
                     else:
                         break
         except BrokenPipeError:

--- a/blockwork/containers/container.py
+++ b/blockwork/containers/container.py
@@ -340,10 +340,8 @@ class Container:
                     line = socket.readline()
                     if not line:
                         break
-                    try:
-                        print(line.decode("utf-8"), end="")
-                    except UnicodeDecodeError:
-                        pass
+                    # Output the line, replace bad characters with escape sequences
+                    print(line.decode("utf-8", errors="backslashreplace"), end="")
             # Get the result (carries the status code)
             # NOTE: Podman sometimes drops the connection during 'wait()' leading
             #       to a connection aborted error, so retry the operation until


### PR DESCRIPTION
`bw build sim -t block` wasn't outputting correctly because an internal tool was outputting a weird character causing a decode error that then caused the entire line to be ignored