### PR TITLE
Improved support for the contained environment

### DIFF
--- a/blockwork/containerfiles/foundation/Containerfile_arm
+++ b/blockwork/containerfiles/foundation/Containerfile_arm
@@ -6,5 +6,5 @@ RUN \
     dnf install -y epel-release && \
     dnf install -y which htop nano gtk2 gtk3 gtk3-devel wget xz cpio iputils xterm \
                    gcc perl bzip2 bzip2-devel tcl tcl-devel tk-devel libnsl \
-                   openssl-devel diffutils && \
+                   openssl-devel diffutils libedit-devel readline-devel && \
     ln -s /usr/lib64/libbz2.so.1 /usr/lib64/libbz2.so.1.0

--- a/blockwork/containerfiles/foundation/Containerfile_x86
+++ b/blockwork/containerfiles/foundation/Containerfile_x86
@@ -6,5 +6,5 @@ RUN \
     dnf install -y epel-release && \
     dnf install -y which htop nano gtk2 gtk3 gtk3-devel wget xz cpio iputils xterm \
                    gcc perl bzip2 bzip2-devel tcl tcl-devel tk-devel libnsl \
-                   openssl-devel diffutils && \
+                   openssl-devel diffutils libedit-devel readline-devel && \
     ln -s /usr/lib64/libbz2.so.1 /usr/lib64/libbz2.so.1.0

--- a/blockwork/containers/container.py
+++ b/blockwork/containers/container.py
@@ -296,9 +296,10 @@ class Container:
                 environment=env,
                 # Setup folders to bind in
                 mounts     =mounts,
-                # Provide an anonymous volume for '/tmp' (using a tmpfs mount
-                # implicitly adds 'noexec' preventing binaries executing)
-                volumes    =["/tmp:/tmp"],
+                # Provide an anonymous volume for /tmp, /root, /var/log, /var/cache
+                # (using a tmpfs mount implicitly adds 'noexec' that prevents
+                # binaries from executing)
+                volumes    =[f"{x}:{x}" for x in ["/tmp", "/root", "/var/log", "/var/cache"]],
                 # Shared network with host
                 network    ="host",
                 # Set the UID to 0


### PR DESCRIPTION
 * Adding some more temporary writeable directories (`/root`, `/var/log`, `/var/cache`) - this fixes a few error/warning messages;
 * Adding `libedit-devel` and `readline-devel` to the foundation container spec for better compatibility