### PR TITLE
Pass through context to transforms

### DIFF
--- a/blockwork/activities/tools.py
+++ b/blockwork/activities/tools.py
@@ -87,10 +87,10 @@ def tool(ctx         : Context,
     if (tool_ver := Tool.get(vendor, name, version)) is None:
         raise Exception(f"Cannot locate tool for {tool}")
     # See if there is an action registered
-    if (act_def := tool_ver.get_action(ctx, action)) is None:
+    if (act_def := tool_ver.get_action(action)) is None:
         raise Exception(f"No action known for '{action}' on tool {tool}")
     # Run the action and forward the exit code
     container = Foundation(ctx, hostname=f"{ctx.config.project}_{tool}_{action}")
     sys.exit(container.invoke(ctx,
-                              act_def(*runargs),
+                              act_def(ctx, *runargs),
                               readonly=(ToolMode(tool_mode) == ToolMode.READONLY)))

--- a/blockwork/activities/tools.py
+++ b/blockwork/activities/tools.py
@@ -87,10 +87,10 @@ def tool(ctx         : Context,
     if (tool_ver := Tool.get(vendor, name, version)) is None:
         raise Exception(f"Cannot locate tool for {tool}")
     # See if there is an action registered
-    if (act_def := tool_ver.get_action(action)) is None:
+    if (act_def := tool_ver.get_action(ctx, action)) is None:
         raise Exception(f"No action known for '{action}' on tool {tool}")
     # Run the action and forward the exit code
     container = Foundation(ctx, hostname=f"{ctx.config.project}_{tool}_{action}")
     sys.exit(container.invoke(ctx,
-                              act_def(ctx, *runargs),
+                              act_def(*runargs),
                               readonly=(ToolMode(tool_mode) == ToolMode.READONLY)))

--- a/blockwork/build/transform.py
+++ b/blockwork/build/transform.py
@@ -70,7 +70,7 @@ class Transform(RegisteredMethod):
         m_inputs = { x.strip(".").replace(".", "_"): y for x, y in inputs.items() }
         n_inputs = SimpleNamespace(**m_inputs)
         # Invoke the transform
-        yield from self.method(n_tools, n_inputs, cntr_dirx)
+        yield from self.method(ctx, n_tools, n_inputs, cntr_dirx)
 
     @classmethod
     def tool(cls, tool : Tool) -> Callable:

--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -377,6 +377,4 @@ class Invocation:
             # Otherwise, just pass through the argument
             else:
                 args.append(arg)
-
-        breakpoint()
         return args

--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -107,12 +107,12 @@ class Version:
         else:
             return Path(self.tool.name) / self.version
 
-    def get_action(self, name : str) -> Union[Callable, None]:
-        if (action := self.tool.get_action(name)) is None:
+    def get_action(self, context: Context, name : str) -> Union[Callable, None]:
+        if (action := self.tool.get_action(context, name)) is None:
             return None
         # Return a wrapper that inserts the active version
-        def _wrap(context, *args, **kwargs):
-            return action(context, self, *args, **kwargs)
+        def _wrap(*args, **kwargs):
+            return action(self, *args, **kwargs)
         return _wrap
 
 
@@ -229,7 +229,7 @@ class Tool(RegisteredClass, metaclass=Singleton):
             return method
         return _inner
 
-    def get_action(self, name : str) -> Union[Callable, None]:
+    def get_action(self, context: Context, name : str) -> Union[Callable, None]:
         """
         Return an action registered for this tool if known.
 
@@ -245,7 +245,7 @@ class Tool(RegisteredClass, metaclass=Singleton):
         # The method held in the actions dictionary is unbound, so this wrapper
         # provides the instance as the first argument
         def _wrap(*args, **kwargs):
-            return raw_act(self, *args, **kwargs)
+            return raw_act(self, context, *args, **kwargs)
         return _wrap
 
     # ==========================================================================
@@ -377,4 +377,6 @@ class Invocation:
             # Otherwise, just pass through the argument
             else:
                 args.append(arg)
+
+        breakpoint()
         return args

--- a/example/infra/tools/compilers.py
+++ b/example/infra/tools/compilers.py
@@ -23,7 +23,7 @@ class GCC(Tool):
         script = [
             f"wget --quiet https://mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-{vernum}/gcc-{vernum}.tar.gz",
             f"tar -xf gcc-{vernum}.tar.gz",
-            f"cd gcc-{vernum}"
+            f"cd gcc-{vernum}",
             "bash ./contrib/download_prerequisites",
             "cd ..",
             "mkdir -p objdir",

--- a/example/infra/transforms/lint.py
+++ b/example/infra/transforms/lint.py
@@ -15,7 +15,8 @@ def verilator_lint(ctx      : Context,
                    tools    : SimpleNamespace,
                    inputs   : SimpleNamespace,
                    out_dirx : Path) -> Iterable[Union[Invocation, Path]]:
-    yield tools.verilator.get_action(ctx, "run")(
+    yield tools.verilator.get_action("run")(
+        ctx,
         "--lint-only",
         "-Wall",
         *inputs.sv

--- a/example/infra/transforms/lint.py
+++ b/example/infra/transforms/lint.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from typing import Iterable, List, Union
 
 from blockwork.build import Transform
+from blockwork.context import Context
 from blockwork.tools import Invocation, Version
 
 from infra.tools.simulators import Verilator
@@ -10,10 +11,11 @@ from infra.tools.simulators import Verilator
 @Transform.register()
 @Transform.tool(Verilator)
 @Transform.input(".sv")
-def verilator_lint(tools    : SimpleNamespace,
+def verilator_lint(ctx      : Context,
+                   tools    : SimpleNamespace,
                    inputs   : SimpleNamespace,
                    out_dirx : Path) -> Iterable[Union[Invocation, Path]]:
-    yield tools.verilator.get_action("run")(
+    yield tools.verilator.get_action(ctx, "run")(
         "--lint-only",
         "-Wall",
         *inputs.sv

--- a/example/infra/transforms/templating.py
+++ b/example/infra/transforms/templating.py
@@ -24,5 +24,5 @@ def mako(ctx      : Context,
     cmd += f"fh.write(Template(filename='{tmpl}').render());"
     cmd += f"fh.flush();"
     cmd += f"fh.close()"
-    yield tools.pythonsite.get_action(ctx, "run")("-c", cmd)
+    yield tools.pythonsite.get_action("run")(ctx, "-c", cmd)
     yield out_dirx / fname

--- a/example/infra/transforms/templating.py
+++ b/example/infra/transforms/templating.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from typing import Iterable, Union
 
 from blockwork.build import Transform
+from blockwork.context import Context
 from blockwork.tools import Tool, Invocation
 
 from infra.tools.misc import PythonSite
@@ -11,7 +12,8 @@ from infra.tools.misc import PythonSite
 @Transform.tool(PythonSite)
 @Transform.input(".sv.mako")
 @Transform.output(".sv")
-def mako(tools    : SimpleNamespace,
+def mako(ctx      : Context,
+         tools    : SimpleNamespace,
          inputs   : SimpleNamespace,
          out_dirx : Path) -> Iterable[Union[Invocation, Path]]:
     assert len(inputs.sv_mako) == 1
@@ -22,5 +24,5 @@ def mako(tools    : SimpleNamespace,
     cmd += f"fh.write(Template(filename='{tmpl}').render());"
     cmd += f"fh.flush();"
     cmd += f"fh.close()"
-    yield tools.pythonsite.get_action("run")("-c", cmd)
+    yield tools.pythonsite.get_action(ctx, "run")("-c", cmd)
     yield out_dirx / fname

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -21,6 +21,12 @@ from blockwork.context import Context
 from blockwork.common.registry import RegistryError
 from blockwork.tools import Invocation, Require, Tool, ToolError, Version
 
+
+class DummyContext(Context):
+    "Dummy context object used to pass type checking when we know it won't be used."
+    def __init__(self):
+        pass
+
 class TestTools:
     """ Exercise tool and version definitions """
 
@@ -313,9 +319,9 @@ class TestTools:
             def other_thing(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
                 return Invocation(version, execute=Tool.ROOT / "bin" / "thing")
         # Invoke the 'do_something' action
-        act = Widget().get_version("1.1").get_action("ignored_context", "do_something")
+        act = Widget().get_version("1.1").get_action("do_something")
         assert callable(act)
-        ivk = act("the argument", "ignored")
+        ivk = act(DummyContext(), "the argument", "ignored")
         assert isinstance(ivk, Invocation)
         # Check attributes of the invocation
         assert ivk.version is Widget().get_version("1.1")
@@ -325,9 +331,9 @@ class TestTools:
         assert ivk.interactive
         assert ivk.binds == [Path("/a/b/c")]
         # Get the default action
-        act_dft = Widget().get_action("ignored_context", "default")
+        act_dft = Widget().get_action("default")
         assert callable(act_dft)
-        ivk_dft = act_dft(Widget().get_version("1.1"), "abc", "123")
+        ivk_dft = act_dft(DummyContext(), Widget().get_version("1.1"), "abc", "123")
         assert isinstance(ivk_dft, Invocation)
         assert ivk_dft.version is Widget().get_version("1.1")
         assert ivk_dft.execute == Tool.ROOT / "bin" / "thing"
@@ -370,9 +376,9 @@ class TestTools:
                         paths    = { "PATH": [Tool.ROOT / "bin"] })
             ]
         # Via the tool
-        assert Widget().get_action("ignored_context", "blah") is None
+        assert Widget().get_action("blah") is None
         # Via the version
-        assert Widget().get_version("1.1").get_action("ignored_context", "blah") is None
+        assert Widget().get_version("1.1").get_action("blah") is None
 
     def test_tool_action_bad_name(self, tmp_path : Path) -> None:
         """ Check that a non-existent action returns 'None' """
@@ -391,9 +397,9 @@ class TestTools:
             def blah(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
                 return Invocation(version, Tool.ROOT / "bin" / "blah")
         # Via the tool
-        assert Widget().get_action("ignored_context", "not_blah") is None
+        assert Widget().get_action("not_blah") is None
         # Via the version
-        assert Widget().get_version("1.1").get_action("ignored_context", "not_blah") is None
+        assert Widget().get_version("1.1").get_action("not_blah") is None
 
     def test_registry(self, tmp_path : Path) -> None:
         """ Exercise search functionality of the registry """

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -313,9 +313,9 @@ class TestTools:
             def other_thing(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
                 return Invocation(version, execute=Tool.ROOT / "bin" / "thing")
         # Invoke the 'do_something' action
-        act = Widget().get_version("1.1").get_action("do_something")
+        act = Widget().get_version("1.1").get_action("ignored_context", "do_something")
         assert callable(act)
-        ivk = act("ignored_context", "the argument", "ignored")
+        ivk = act("the argument", "ignored")
         assert isinstance(ivk, Invocation)
         # Check attributes of the invocation
         assert ivk.version is Widget().get_version("1.1")
@@ -325,9 +325,9 @@ class TestTools:
         assert ivk.interactive
         assert ivk.binds == [Path("/a/b/c")]
         # Get the default action
-        act_dft = Widget().get_action("default")
+        act_dft = Widget().get_action("ignored_context", "default")
         assert callable(act_dft)
-        ivk_dft = act_dft("ignored_context", Widget().get_version("1.1"), "abc", "123")
+        ivk_dft = act_dft(Widget().get_version("1.1"), "abc", "123")
         assert isinstance(ivk_dft, Invocation)
         assert ivk_dft.version is Widget().get_version("1.1")
         assert ivk_dft.execute == Tool.ROOT / "bin" / "thing"
@@ -370,9 +370,9 @@ class TestTools:
                         paths    = { "PATH": [Tool.ROOT / "bin"] })
             ]
         # Via the tool
-        assert Widget().get_action("blah") is None
+        assert Widget().get_action("ignored_context", "blah") is None
         # Via the version
-        assert Widget().get_version("1.1").get_action("blah") is None
+        assert Widget().get_version("1.1").get_action("ignored_context", "blah") is None
 
     def test_tool_action_bad_name(self, tmp_path : Path) -> None:
         """ Check that a non-existent action returns 'None' """
@@ -391,9 +391,9 @@ class TestTools:
             def blah(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
                 return Invocation(version, Tool.ROOT / "bin" / "blah")
         # Via the tool
-        assert Widget().get_action("not_blah") is None
+        assert Widget().get_action("ignored_context", "not_blah") is None
         # Via the version
-        assert Widget().get_version("1.1").get_action("not_blah") is None
+        assert Widget().get_version("1.1").get_action("ignored_context", "not_blah") is None
 
     def test_registry(self, tmp_path : Path) -> None:
         """ Exercise search functionality of the registry """


### PR DESCRIPTION
Moved context pass-through for actions from the action call to get_action...

perhaps later this should be moved to the tool instantiation?