### PR TITLE
use shutil get term size as it has fallback

### DIFF
--- a/blockwork/containers/container.py
+++ b/blockwork/containers/container.py
@@ -17,6 +17,7 @@ import dataclasses
 import itertools
 import logging
 import os
+import shutil
 import time
 from pathlib import Path
 from threading import Event
@@ -258,7 +259,7 @@ class Container:
                 env["DISPLAY"] = f"{Runtime.get_host_address()}:0"
                 logging.debug(f"Setting DISPLAY to {env['DISPLAY']}")
         # Expose terminal dimensions
-        tsize = os.get_terminal_size()
+        tsize = shutil.get_terminal_size()
         logging.debug(f"Setting terminal to {tsize.columns}x{tsize.lines}")
         env["LINES"]   = str(tsize.lines)
         env["COLUMNS"] = str(tsize.columns)


### PR DESCRIPTION
[https://docs.python.org/3/library/shutil.html#shutil.get_terminal_size](https://docs.python.org/3/library/shutil.html#shutil.get_terminal_size)

This should fix inappropriate ioctl errors when not on a terminal