### PR TITLE
Add dependency functionality to config (#31)

### DIFF
--- a/blockwork/activities/workflow.py
+++ b/blockwork/activities/workflow.py
@@ -41,6 +41,6 @@ def workflow(ctx : Context, project: str, target: str, workflow_name: str) -> No
     target_parser = parser.Element(ctx, site_config, project_config)
     target_config = target_parser.parse_target(target, wf.TARGET_TYPE)
 
-    config = Config(site=site_config, project=project_config, target=target_config)
+    config = Config(ctx=ctx, site=site_config, project=project_config, target=target_config)
 
-    wf(ctx, config).exec()
+    wf(config).exec()

--- a/blockwork/config/base.py
+++ b/blockwork/config/base.py
@@ -12,20 +12,88 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+from typing import Any, Iterable, Optional, Protocol, overload
 from blockwork.common.checkeddataclasses import dataclass
 
+class _Resolver(Protocol):
+    'Takes a path or list of paths and returns a path or list of paths (respectively)'
+    @overload
+    def __call__(self, paths: list[str]) -> list[str]: ...
+    @overload
+    def __call__(self, paths: str) -> str: ...
+    def __call__(self, paths) -> Any: ...
 
-@dataclass
+@dataclass(kw_only=True)
 class Site:
     'Base class for site configuration'
     projects: dict[str, str]
 
-@dataclass
+@dataclass(kw_only=True)
 class Project:
     'Base class for project configuration'
     blocks: dict[str, str]
 
-@dataclass
+
+@dataclass(kw_only=True)
+class ElementContext:
+    'Context object bound on to each element to keep track of where it came from'
+    block: str
+    config: Path
+
+@dataclass(kw_only=True)
 class Element:
     'Base class for element configuration'
-    pass
+    _context: Optional[ElementContext] = None
+
+    def iter_sub_elements(self) -> Iterable["Element"]:
+        '''
+        Yields any sub-elements which are used as part of this one.
+
+        Implementation notes:
+            - This function must be implemented when sub-elements are used.
+        '''
+        yield from []
+
+    def resolve_input_paths(self, resolver: _Resolver):
+        '''
+        Resolves relative 'input' paths specified in the config to absolute ones based 
+        on the resolver argument. Where input paths are paths which reference either
+        static paths from the repository, or paths which refer to files which are output 
+        from transforms.
+        
+        The resolver is expected to take a relative path and return an absolute path.
+
+        Implementation notes:
+            - This function must be implemented when config specifies paths to static
+              or generated files.
+            - The element is expected to patch itself with the output of the resolver
+              for each path, for example::
+              
+            self.a_path = resolver(self.a_path)
+
+        '''
+        pass
+
+@dataclass(kw_only=True)
+class Transform(Element):
+    'Base class for transforms'
+
+    def resolve_output_paths(self, resolver: _Resolver):
+        '''
+        Resolves relative 'output' paths specified in the config to absolute ones based 
+        on the resolver argument. Where output paths are absolute paths which can be 
+        generated based on the transform inputs.
+
+        The resolver is expected to take a relative path and return an absolute path.
+
+        Implementation notes:
+            - This function must be implemented when config transforms are used to
+              create files.
+            - The element is expected to patch itself with the output of the resolver
+              for each path, for example::
+              
+            self.a_path = resolver(self.a_path)
+
+        '''
+        pass

--- a/blockwork/config/base.py
+++ b/blockwork/config/base.py
@@ -32,13 +32,13 @@ class Site:
 @dataclass(kw_only=True)
 class Project:
     'Base class for project configuration'
-    blocks: dict[str, str]
+    units: dict[str, str]
 
 
 @dataclass(kw_only=True)
 class ElementContext:
     'Context object bound on to each element to keep track of where it came from'
-    block: str
+    unit: str
     config: Path
 
 @dataclass(kw_only=True)

--- a/blockwork/config/config.py
+++ b/blockwork/config/config.py
@@ -44,8 +44,8 @@ class Linker:
         self.pairs: dict[tuple[str, str], Path] = {}
 
     def link_inputs(self, element: base.Element):
-        block = cast(base.ElementContext, element._context).block
-        block_root = self.config.ctx.host_root / self.config.project.blocks[block]
+        unit = cast(base.ElementContext, element._context).unit
+        block_root = self.config.ctx.host_root / self.config.project.units[unit]
 
         @overload
         def resolve(paths: str) -> str: ...
@@ -57,7 +57,7 @@ class Linker:
 
             resolved_paths: list[str] = []
             for path in paths:
-                pair = (block, path)
+                pair = (unit, path)
                 if pair in self.pairs:
                     full_path = self.pairs[pair]
                 else:
@@ -68,8 +68,8 @@ class Linker:
         element.resolve_input_paths(resolve)
 
     def link_outputs(self, element: base.Transform):
-        block = cast(base.ElementContext, element._context).block
-        block_scratch = self.config.ctx.host_scratch / self.config.project.blocks[block]
+        unit = cast(base.ElementContext, element._context).unit
+        block_scratch = self.config.ctx.host_scratch / self.config.project.units[unit]
 
         @overload
         def resolve(paths: str) -> str: ...
@@ -82,7 +82,7 @@ class Linker:
             resolved_paths: list[str] = []
             for path in paths:
                 full_path = block_scratch / path
-                self.pairs[(block, path)] = full_path
+                self.pairs[(unit, path)] = full_path
                 resolved_paths.append(full_path.as_posix())
 
             return resolved_paths[0] if is_single else resolved_paths

--- a/blockwork/config/config.py
+++ b/blockwork/config/config.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 from typing import Iterable, cast, overload, TYPE_CHECKING
-from blockwork.common.registry import RegisteredClass
-from blockwork.common.singleton import Singleton
+from ..common.registry import RegisteredClass
+from ..common.singleton import Singleton
 if TYPE_CHECKING:
-    from blockwork.context import Context
+    from ..context import Context
 from . import base
 
 class Config(RegisteredClass, metaclass=Singleton):

--- a/blockwork/config/config.py
+++ b/blockwork/config/config.py
@@ -1,6 +1,90 @@
+from pathlib import Path
+from typing import Iterable, cast, overload, TYPE_CHECKING
 from blockwork.common.registry import RegisteredClass
 from blockwork.common.singleton import Singleton
+if TYPE_CHECKING:
+    from blockwork.context import Context
+from . import base
 
 class Config(RegisteredClass, metaclass=Singleton):
-    'This is just used point to the modules which register configuration'
-    pass
+    'Configuration object which is passed into workflows'
+    def __init__(self, ctx: "Context", site: base.Site, project: base.Project, target: base.Element) -> None:
+        self.ctx = ctx
+        self.site = site
+        self.project = project
+        self.target = target
+
+    def depth_first_elements(self, element: base.Element) -> Iterable[base.Element]:
+        'Recures elements and yields depths first'
+        for sub_element in element.iter_sub_elements():
+            yield from self.depth_first_elements(sub_element)
+        yield element
+
+    def resolve(self):
+        'Resolves paths in the config'
+        linker = Linker(self)
+        for element in self.depth_first_elements(self.target):
+            if isinstance(element, base.Transform):
+                linker.link_outputs(element)
+
+        for element in self.depth_first_elements(self.target):
+            linker.link_inputs(element)
+
+class Linker:
+    '''
+    This class is responsible for finalising input and output paths
+    and linking them together.
+
+    @ed.kotarski: The next extension to this will be to use that
+    information to create dependencies between transforms to determine 
+    the order they need to be run.
+    '''
+    def __init__(self, config: Config):
+        self.config = config
+        self.pairs: dict[tuple[str, str], Path] = {}
+
+    def link_inputs(self, element: base.Element):
+        block = cast(base.ElementContext, element._context).block
+        block_root = self.config.ctx.host_root / self.config.project.blocks[block]
+
+        @overload
+        def resolve(paths: str) -> str: ...
+        @overload
+        def resolve(paths: list[str]) -> list[str]: ...
+        def resolve(paths):
+            if (is_single := isinstance(paths, str)):
+                paths = [paths]
+
+            resolved_paths: list[str] = []
+            for path in paths:
+                pair = (block, path)
+                if pair in self.pairs:
+                    full_path = self.pairs[pair]
+                else:
+                    full_path = (block_root / path)
+                resolved_paths.append(full_path.as_posix())
+            return resolved_paths[0] if is_single else resolved_paths
+
+        element.resolve_input_paths(resolve)
+
+    def link_outputs(self, element: base.Transform):
+        block = cast(base.ElementContext, element._context).block
+        block_scratch = self.config.ctx.host_scratch / self.config.project.blocks[block]
+
+        @overload
+        def resolve(paths: str) -> str: ...
+        @overload
+        def resolve(paths: list[str]) -> list[str]: ...
+        def resolve(paths):
+            if (is_single := isinstance(paths, str)):
+                paths = [paths]
+
+            resolved_paths: list[str] = []
+            for path in paths:
+                full_path = block_scratch / path
+                self.pairs[(block, path)] = full_path
+                resolved_paths.append(full_path.as_posix())
+
+            return resolved_paths[0] if is_single else resolved_paths
+
+        element.resolve_output_paths(resolve)

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -16,6 +16,7 @@ import functools
 from pathlib import Path
 from blockwork.common.registry import RegisteredClass
 from blockwork.common.singleton import Singleton
+from blockwork.config import base, Config
 
 
 class Workflow(RegisteredClass, metaclass=Singleton):
@@ -24,14 +25,25 @@ class Workflow(RegisteredClass, metaclass=Singleton):
     # Tool root locator
     ROOT : Path = Path("/__tool_root__")
 
+    # Config types this workflow uses
+    SITE_TYPE = base.Site
+    PROJECT_TYPE = base.Project
+    TARGET_TYPE = base.Element
 
-    def __init__(self) -> None:
-        ...
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        # Resolve input and output paths
+        self.config.resolve()
 
+    def exec(self):
+        'Run the workflow'
+        raise NotImplementedError
+
+    @classmethod
     @property
     @functools.lru_cache()
-    def name(self) -> str:
-        return type(self).__name__.lower()
+    def name(cls) -> str:
+        return cls.__name__.lower()
 
     # ==========================================================================
     # Registry Handling
@@ -42,8 +54,6 @@ class Workflow(RegisteredClass, metaclass=Singleton):
         if workflow in RegisteredClass.LOOKUP_BY_OBJ[cls]:
             return workflow
         else:
-            RegisteredClass.LOOKUP_BY_NAME[cls][workflow().name] = workflow
+            RegisteredClass.LOOKUP_BY_NAME[cls][workflow.name] = workflow
             RegisteredClass.LOOKUP_BY_OBJ[cls][workflow] = workflow
             return workflow
-
-

--- a/example/bench/testbench.yaml
+++ b/example/bench/testbench.yaml
@@ -1,0 +1,4 @@
+!Testbench
+design: !Design top
+bench_python: bench/bench.py
+bench_make: bench/Makefile

--- a/example/design/top/design.yaml
+++ b/example/design/top/design.yaml
@@ -1,5 +1,9 @@
 !Design
 top: top
+transforms:
+  - !Mako
+    template: top.sv.mako
+    output: top.sv
 sources:
   - adder.sv
   - counter.sv

--- a/example/infra/config/config.py
+++ b/example/infra/config/config.py
@@ -20,25 +20,42 @@ from blockwork.config.parser import ElementConverter
 
 
 @registry.site.register(DataclassConverter)
-@dataclass
+@dataclass(kw_only=True)
 class Site(base.Site):
     pass
 
 
 @registry.project.register(DataclassConverter)
-@dataclass
+@dataclass(kw_only=True)
 class Project(base.Project):
     pass
 
 
 @registry.element.register(ElementConverter)
-@dataclass
+@dataclass(kw_only=True)
 class Design(base.Element):
     top: str
-    sources: list[str] = field(default_factory=list)
+    sources: list[str]
+    transforms: list[base.Transform] = field(default_factory=list)
+
+    def iter_sub_elements(self):
+        yield from self.transforms
+
+    def resolve_input_paths(self, resolved):
+        self.sources = resolved(self.sources)
 
 
 @registry.element.register(ElementConverter)
-@dataclass
+@dataclass(kw_only=True)
 class Testbench(base.Element):
     design: Design
+    bench_python: str
+    bench_make: str
+
+    def iter_sub_elements(self):
+        yield self.design
+
+    def resolve_input_paths(self, resolver):
+        self.bench_python = resolver(self.bench_python)
+        self.bench_make = resolver(self.bench_make)
+

--- a/example/infra/transforms/lint.py
+++ b/example/infra/transforms/lint.py
@@ -1,11 +1,10 @@
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Iterable, List, Union
+from typing import Iterable, Union
 
 from blockwork.build import Transform
 from blockwork.context import Context
-from blockwork.tools import Invocation, Version
-
+from blockwork.tools import Invocation
 from infra.tools.simulators import Verilator
 
 @Transform.register()

--- a/example/infra/transforms/templating.py
+++ b/example/infra/transforms/templating.py
@@ -1,28 +1,45 @@
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Iterable, Union
-
+from blockwork.config import registry
+from blockwork.config.parser import ElementConverter
+from blockwork.common.checkeddataclasses import dataclass
+from blockwork.config import base
 from blockwork.build import Transform
 from blockwork.context import Context
-from blockwork.tools import Tool, Invocation
-
+from blockwork.tools.tool import Invocation
 from infra.tools.misc import PythonSite
 
-@Transform.register()
-@Transform.tool(PythonSite)
-@Transform.input(".sv.mako")
-@Transform.output(".sv")
-def mako(ctx      : Context,
-         tools    : SimpleNamespace,
-         inputs   : SimpleNamespace,
-         out_dirx : Path) -> Iterable[Union[Invocation, Path]]:
-    assert len(inputs.sv_mako) == 1
-    tmpl  = inputs.sv_mako[0]
-    fname = tmpl.name.rstrip(".mako")
-    cmd  = "from mako.template import Template;"
-    cmd += f"fh = open('{out_dirx / fname}', 'w');"
-    cmd += f"fh.write(Template(filename='{tmpl}').render());"
-    cmd += f"fh.flush();"
-    cmd += f"fh.close()"
-    yield tools.pythonsite.get_action("run")(ctx, "-c", cmd)
-    yield out_dirx / fname
+
+@registry.element.register(ElementConverter)
+@dataclass(kw_only=True)
+class Mako(base.Transform):
+    template: str
+    output: str
+
+    def resolve_input_paths(self, resolve):
+        self.template = resolve(self.template)
+
+    def resolve_output_paths(self, resolved):
+        self.output = resolved(self.output)
+
+
+    @Transform.register("mako")
+    @Transform.tool(PythonSite)
+    @Transform.input(".sv.mako")
+    @Transform.output(".sv")
+    @staticmethod
+    def exec(ctx      : Context,
+             tools    : SimpleNamespace,
+             inputs   : SimpleNamespace,
+             out_dirx : Path) -> Iterable[Union[Invocation, Path]]:
+        assert len(inputs.sv_mako) == 1
+        tmpl  = inputs.sv_mako[0]
+        fname = tmpl.name.rstrip(".mako")
+        cmd  = "from mako.template import Template;"
+        cmd += f"fh = open('{out_dirx / fname}', 'w');"
+        cmd += f"fh.write(Template(filename='{tmpl}').render());"
+        cmd += "fh.flush();"
+        cmd += "fh.close()"
+        yield tools.pythonsite.get_action("run")(ctx, "-c", cmd)
+        yield out_dirx / fname

--- a/example/infra/workflows/lint.py
+++ b/example/infra/workflows/lint.py
@@ -13,11 +13,27 @@
 # limitations under the License.
 
 from blockwork.workflows import Workflow
-from ..config.config import Site, Project, Design
+from ..config.config import Site, Project, Design, Testbench
 
 
 @Workflow.register()
-class Lint(Workflow):    
-    def __call__(self, site: Site, project: Project, target: Design):
-        print(site, project, target)
+class Lint(Workflow):
+    SITE_TYPE = Site
+    PROJECT_TYPE = Project
+    TARGET_TYPE = Design
+
+    def exec(self):
+        # Dummy for now
+        pass
+
+@Workflow.register()
+class Sim(Workflow):
+    SITE_TYPE = Site
+    PROJECT_TYPE = Project
+    TARGET_TYPE = Testbench
+
+    def exec(self):
+        # Dummy for now
+        pass
+
 

--- a/example/projects/example.yaml
+++ b/example/projects/example.yaml
@@ -1,4 +1,4 @@
 !Project
-blocks:
+units:
   top: design/top
   bench: bench

--- a/example/projects/example.yaml
+++ b/example/projects/example.yaml
@@ -1,3 +1,4 @@
 !Project
 blocks:
   top: design/top
+  bench: bench


### PR DESCRIPTION
Lots of configuration infra to link paths output from transforms to paths input into other transforms and config values

This is not used yet but is a stepping stone to getting workflows working properly.

The next thing will be to extend the `config.Linker` to calculate dependencies between transforms (most of the way there) and then we can run the transforms in order (until later when we need to deal with parallelism and it gets a bit more complicated)

