### PR TITLE
Less Eager Tool Re-installs

### DIFF
--- a/blockwork/activities/info.py
+++ b/blockwork/activities/info.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 import click
 from rich.console import Console
 from rich.table import Table
 
+import blockwork
 from ..context import Context
 
 @click.command()
@@ -27,4 +30,5 @@ def info(ctx : Context):
     table.add_row("Host Root Directory", ctx.host_root.as_posix())
     table.add_row("Container Root Directory", ctx.container_root.as_posix())
     table.add_row("Configuration File", ctx.config_path.as_posix())
+    table.add_row("Blockwork Install", Path(blockwork.__file__).parent.as_posix())
     Console().print(table)

--- a/blockwork/bootstrap/tools.py
+++ b/blockwork/bootstrap/tools.py
@@ -52,7 +52,13 @@ def install_tools(context : Context, last_run : datetime) -> bool:
         tool_file = Path(inspect.getfile(type(tool.tool)))
         # If the tool install location already exists and install has been run
         # more recently than the definition file was updated, then skip
-        if tool.location.exists() and last_run >= datetime.fromtimestamp(tool_file.stat().st_mtime):
+        if (
+            tool.location.exists() and
+            (
+                datetime.fromtimestamp(tool.location.stat().st_mtime) >=
+                datetime.fromtimestamp(tool_file.stat().st_mtime)
+            )
+        ):
             logging.debug(f" - {idx}: Tool {tool_id} is already installed")
             continue
         # Attempt to install

--- a/blockwork/bootstrap/tools.py
+++ b/blockwork/bootstrap/tools.py
@@ -14,6 +14,7 @@
 
 import inspect
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -52,30 +53,28 @@ def install_tools(context : Context, last_run : datetime) -> bool:
         tool_file = Path(inspect.getfile(type(tool.tool)))
         # If the tool install location already exists and install has been run
         # more recently than the definition file was updated, then skip
-        if (
-            tool.location.exists() and
-            (
-                datetime.fromtimestamp(tool.location.stat().st_mtime) >=
-                datetime.fromtimestamp(tool_file.stat().st_mtime)
-            )
-        ):
-            logging.debug(f" - {idx}: Tool {tool_id} is already installed")
-            continue
+        if tool.location.exists():
+            loc_date = datetime.fromtimestamp(tool.location.stat().st_mtime)
+            def_date = datetime.fromtimestamp(tool_file.stat().st_mtime)
+            if loc_date >= def_date:
+                logging.debug(f" - {idx}: Tool {tool_id} is already installed")
+                continue
         # Attempt to install
         if act_def := tool.get_action("installer"):
             logging.info(f" - {idx}: Launching installation of {tool_id}")
             invk = act_def(context)
-            if invk is None:
+            if invk is not None:
+                container = Foundation(context, hostname=f"{context.config.project}_install_{tool.id}")
+                exit_code = container.invoke(context,
+                                            act_def(context),
+                                            readonly=False)
+                if exit_code != 0:
+                    raise ToolError(f"Installation of {tool_id} failed")
+            else:
                 logging.debug(f" - {idx}: Installation of {tool_id} produced "
                               f"a null invocation")
-                continue
-            container = Foundation(context, hostname=f"{context.config.project}_install_{tool.id}")
-            exit_code = container.invoke(context,
-                                         act_def(context),
-                                         readonly=False)
-            if exit_code != 0:
-                raise ToolError(f"Installation of {tool_id} failed")
-            else:
-                logging.debug(f" - {idx}: Installation of {tool_id} succeeded")
+            logging.debug(f" - {idx}: Installation of {tool_id} succeeded")
+            # Touch the install folder to ensure its datetime is updated
+            os.utime(tool.location)
         else:
             logging.debug(f" - {idx}: Tool {tool_id} does not define an install action")


### PR DESCRIPTION
 * Tweaks the date comparison to examine the touch date on the install directory compared with the definition file, rather than using the `last_run` date;
 * Use `os.utime(...)` to 'touch' the install directory to ensure datestamp is updated;
 * Added blockwork install location to `bw info` to make it easier to locate.