### PR TITLE
Adding Tool.HOST_ROOT to standardise locating tool installs

### DIFF
--- a/blockwork/bootstrap/tools.py
+++ b/blockwork/bootstrap/tools.py
@@ -51,10 +51,11 @@ def install_tools(context : Context, last_run : datetime) -> bool:
     for idx, tool in enumerate(resolved):
         tool_id = " ".join(tool.id_tuple)
         tool_file = Path(inspect.getfile(type(tool.tool)))
+        host_loc = tool.get_host_path(context)
         # If the tool install location already exists and install has been run
         # more recently than the definition file was updated, then skip
-        if tool.location.exists():
-            loc_date = datetime.fromtimestamp(tool.location.stat().st_mtime)
+        if host_loc.exists():
+            loc_date = datetime.fromtimestamp(host_loc.stat().st_mtime)
             def_date = datetime.fromtimestamp(tool_file.stat().st_mtime)
             if loc_date >= def_date:
                 logging.debug(f" - {idx}: Tool {tool_id} is already installed")
@@ -75,6 +76,6 @@ def install_tools(context : Context, last_run : datetime) -> bool:
                               f"a null invocation")
             logging.debug(f" - {idx}: Installation of {tool_id} succeeded")
             # Touch the install folder to ensure its datetime is updated
-            os.utime(tool.location)
+            os.utime(host_loc)
         else:
             logging.debug(f" - {idx}: Tool {tool_id} does not define an install action")

--- a/blockwork/config/blockwork.py
+++ b/blockwork/config/blockwork.py
@@ -21,8 +21,10 @@ class Blockwork:
     site         : str                 = "./site.yaml"
     root         : str                 = field(default="/project")
     scratch      : str                 = field(default="/scratch")
+    tools        : str                 = field(default="/tools")
     host_scratch : str                 = "../{project}.scratch"
     host_state   : str                 = "../{project}.state"
+    host_tools   : str                 = "../{project}.tools"
     config       : Optional[List[str]] = field(default_factory=list)
     bootstrap    : Optional[List[str]] = field(default_factory=list)
     tooldefs     : Optional[List[str]] = field(default_factory=list)

--- a/blockwork/context.py
+++ b/blockwork/context.py
@@ -80,7 +80,7 @@ class Context:
     @property
     @functools.lru_cache()
     def host_scratch(self) -> Path:
-        # Substitute for {project} if required
+        # Substitute for {project} or {root_dir} if required
         subbed = self.config.host_scratch.format(project=self.config.project,
                                                  root_dir=self.host_root.name)
         # Resolve to an absolute path
@@ -97,7 +97,7 @@ class Context:
     @property
     @functools.lru_cache()
     def host_state(self) -> Path:
-        # Substitute for {project} if required
+        # Substitute for {project} or {root_dir} if required
         subbed = self.config.host_state.format(project=self.config.project,
                                                root_dir=self.host_root.name)
         # Resolve to an absolute path
@@ -110,11 +110,28 @@ class Context:
         # Ensure it exists
         path.mkdir(exist_ok=True, parents=True)
         return path
-    
+
+    @property
+    @functools.lru_cache()
+    def host_tools(self) -> Path:
+        # Substitute for {project} or {root_dir} if required
+        subbed = self.config.host_tools.format(project=self.config.project,
+                                               root_dir=self.host_root.name)
+        # Resolve to an absolute path
+        if subbed.startswith("/"):
+            path = Path(subbed)
+        else:
+            path = self.__host_root / subbed
+        # Fully resolve
+        path = path.resolve().absolute()
+        # Ensure it exists
+        path.mkdir(exist_ok=True, parents=True)
+        return path
+
     @property
     @functools.lru_cache()
     def site(self) -> Path:
-        # Substitute for {project} if required
+        # Substitute for {project} or {root_dir} if required
         subbed = self.config.site.format(project=self.config.project,
                                                  root_dir=self.host_root.name)
         # Resolve to an absolute path
@@ -133,6 +150,10 @@ class Context:
     @property
     def container_scratch(self) -> Path:
         return Path(self.config.scratch)
+
+    @property
+    def container_tools(self) -> Path:
+        return Path(self.config.tools)
 
     @property
     def file(self) -> str:

--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -141,11 +141,29 @@ class Version:
                 return act
             raise e
 
+    def get_host_path(self, ctx : Context):
+        if self.location.is_relative_to(Tool.HOST_ROOT):
+            return ctx.host_tools / self.location.relative_to(Tool.HOST_ROOT)
+        else:
+            return self.location
+
+    def get_container_path(self, ctx : Context, path : Optional[Path] = None):
+        base = ctx.container_tools / self.path_chunk
+        if path:
+            if path.is_relative_to(Tool.CNTR_ROOT):
+                return base / path.relative_to(Tool.CNTR_ROOT)
+            else:
+                return path
+        else:
+            return base
+
+
 class Tool(RegisteredClass, metaclass=Singleton):
     """ Base class for tools """
 
     # Tool root locator
-    ROOT : Path = Path("/__tool_root__")
+    CNTR_ROOT : Path = Path("/__tool_cntr_root__")
+    HOST_ROOT : Path = Path("/__tool_host_root__")
 
     # Default vendor
     NO_VENDOR = "N/A"

--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -141,13 +141,30 @@ class Version:
                 return act
             raise e
 
-    def get_host_path(self, ctx : Context):
+    def get_host_path(self, ctx : Context) -> Path:
+        """
+        Expand the location to get the full path to the tool on the host system.
+        Substitutes Tool.HOST_ROOT for the 'host_tools' path from Context.
+
+        :param ctx: Context object
+        :returns:   Resolved path
+        """
         if self.location.is_relative_to(Tool.HOST_ROOT):
             return ctx.host_tools / self.location.relative_to(Tool.HOST_ROOT)
         else:
             return self.location
 
-    def get_container_path(self, ctx : Context, path : Optional[Path] = None):
+    def get_container_path(self, ctx : Context, path : Optional[Path] = None) -> Path:
+        """
+        Expand the location to get the full path to the tool within the contained
+        environment, substituting Tool.CNTR_ROOT for the 'container_tools' path
+        from Context.
+
+        :param ctx:  Context object
+        :param path: When provided, this path is resolved relative to the tool's
+                     root (if defined using Tool.CNTR_ROOT)
+        :returns:    Resolved path
+        """
         base = ctx.container_tools / self.path_chunk
         if path:
             if path.is_relative_to(Tool.CNTR_ROOT):

--- a/docs/config/bw_yaml.md
+++ b/docs/config/bw_yaml.md
@@ -9,8 +9,10 @@ The file must use a `!Blockwork` tag as its root element, as per the example bel
 project     : example
 root        : /project
 scratch     : /scratch
+tools       : /tools
 host_scratch: ../{project}.scratch
 host_state  : ../{project}.state
+host_tools  : ../{project}.tools
 bootstrap   :
   - infra.bootstrap.setup
 tooldefs    :
@@ -25,16 +27,19 @@ The fields of the `!Blockwork` tag are:
 | project      | :material-check: |                        | Sets the project's name                                                 |
 | root         |                  | `/project`             | Location to map the project's root directory inside the container       |
 | scratch      |                  | `/scratch`             | Location to map the scratch area inside the container                   |
+| tools        |                  | `/tools`               | Location to map the tools inside the container                          |
 | host_scratch |                  | `../{project}.scratch` | Directory to store build objects and other artefacts                    |
 | host_state   |                  | `../{project}.state`   | Directory to store Blockwork's state information for the project        |
+| host_tools   |                  | `../{project}.tools`   | Directory containing tool installations on the host                     |
 | bootstrap    |                  |                        | Python paths containing [Bootstrap](../syntax/bootstrap.md) definitions |
 | tooldefs     |                  |                        | Python paths containing [Tool](../syntax/tools.md) definitions          |
 
 !!!note
 
-    The `host_scratch` and `host_state` directories are resolved relative to the
-    project's root directory on the host, and the `{project}` keyword will be
-    substituted for the projects name (taken from the `project` field).
+    The `host_scratch`, `host_state`, and `host_tools` directories are resolved
+    relative to the project's root directory on the host, and the `{project}`
+    keyword will be substituted for the projects name (taken from the `project`
+    field).
 
 ## Variable Substitutions
 

--- a/docs/syntax/tools.md
+++ b/docs/syntax/tools.md
@@ -19,15 +19,13 @@ from pathlib import Path
 
 from blockwork.tools import Tool, Version
 
-install_root = Path("/some/path/to/tool/installs")
-
 @Tool.register()
 class Verilator(Tool):
     versions = [
-        Version(location = install_root / "verilator-4.106"
+        Version(location = Tool.HOST_ROOT / "verilator-4.106"
                 version  = "4.106"
-                env      = { "VERILATOR_ROOT": Tool.ROOT }
-                paths    = { "PATH": [Tool.ROOT / "bin"] }),
+                env      = { "VERILATOR_ROOT": Tool.CNTR_ROOT }
+                paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] }),
     ]
 ```
 
@@ -44,8 +42,8 @@ Working through this example:
  * Each version is defined by an instance of `Version` where:
 
    * `location` - identifies the path on the **host** where the tool is installed,
-     in this example all tools are installed under a common directory which is
-     referenced via `install_root`;
+     this path can use the `Tool.HOST_ROOT` variable that will be resolved to a
+     complete path using the value specified in the [configuration](../config/bw_yaml.md);
 
    * `version` - sets the version number for the tool, this is to make it distinct
      from other declarations;
@@ -57,7 +55,7 @@ Working through this example:
 
 !!!note
 
-    The `Tool.ROOT` variable points to the equivalent of the `location` when
+    The `Tool.CNTR_ROOT` variable points to the equivalent of the `location` when
     mapped into the container (i.e. the root directory of the bound tool)
 
 Tools are mapped into the container using a standard path structure:
@@ -81,9 +79,9 @@ keyword to be provided which adds an extra section into the path. For example:
 class Make(Tool):
     vendor   = "GNU"
     versions = [
-        Version(location = install_root / "make-4.4",
+        Version(location = Tool.HOST_ROOT / "make-4.4",
                 version  = "4.4",
-                paths    = { "PATH": [Tool.ROOT / "bin"] }),
+                paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] }),
     ]
 ```
 
@@ -106,13 +104,13 @@ be bound when a version is not explicitly given:
 class Make(Tool):
     vendor   = "GNU"
     versions = [
-        Version(location = install_root / "make-4.4",
+        Version(location = Tool.HOST_ROOT / "make-4.4",
                 version  = "4.4",
-                paths    = { "PATH": [Tool.ROOT / "bin"] },
+                paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] },
                 default  = True),
-        Version(location = install_root / "make-4.3",
+        Version(location = Tool.HOST_ROOT / "make-4.3",
                 version  = "4.3",
-                paths    = { "PATH": [Tool.ROOT / "bin"] }),
+                paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] }),
     ]
 ```
 
@@ -133,21 +131,21 @@ from blockwork.tools import Require, Tool, Version
 class Python(Tool):
     """ Base Python installation """
     versions = [
-        Version(location = install_root / "python-3.11.4",
+        Version(location = Tool.HOST_ROOT / "python-3.11.4",
                 version  = "3.11.4",
-                paths    = { "PATH"           : [Tool.ROOT / "bin"],
-                             "LD_LIBRARY_PATH": [Tool.ROOT / "lib"] })
+                paths    = { "PATH"           : [Tool.CNTR_ROOT / "bin"],
+                             "LD_LIBRARY_PATH": [Tool.CNTR_ROOT / "lib"] })
     ]
 
 @Tool.register()
 class PythonSite(Tool):
     """ Versioned package installation """
     versions = [
-        Version(location = install_root / "python-site-3.11.4",
+        Version(location = Tool.HOST_ROOT / "python-site-3.11.4",
                 version  = "3.11.4",
-                env      = { "PYTHONUSERBASE": Tool.ROOT },
-                paths    = { "PATH"      : [Tool.ROOT / "bin"],
-                             "PYTHONPATH": [Tool.ROOT / "lib" / "python3.11" / "site-packages"] },
+                env      = { "PYTHONUSERBASE": Tool.CNTR_ROOT },
+                paths    = { "PATH"      : [Tool.CNTR_ROOT / "bin"],
+                             "PYTHONPATH": [Tool.CNTR_ROOT / "lib" / "python3.11" / "site-packages"] },
                 requires = [Require(Python, "3.11.4")]),
     ]
 ```
@@ -180,7 +178,7 @@ class GTKWave(Tool):
     versions = [
         Version(location = tool_root / "gtkwave-3.3.113",
                 version  = "3.3.113",
-                paths    = { "PATH": [Tool.ROOT / "src"] }),
+                paths    = { "PATH": [Tool.CNTR_ROOT / "src"] }),
     ]
 
     @Tool.action("GTKWave", default=True)
@@ -192,7 +190,7 @@ class GTKWave(Tool):
         path = Path(wavefile).absolute()
         return Invocation(
             version = version,
-            execute = Tool.ROOT / "src" / "gtkwave",
+            execute = Tool.CNTR_ROOT / "src" / "gtkwave",
             args    = [path, *args],
             display = True,
             binds   = [path.parent]
@@ -250,16 +248,14 @@ from pathlib import Path
 from blockwork.tools import Invocation, Require, Tool, Version
 from blockwork.context import Context
 
-install_root = Path("/some/path/to/tool/installs")
-
 @Tool.register()
 class Python(Tool):
     """ Base Python installation """
     versions = [
-        Version(location = install_root / "python-3.11.4",
+        Version(location = Tool.HOST_ROOT / "python-3.11.4",
                 version  = "3.11.4",
-                paths    = { "PATH"           : [Tool.ROOT / "bin"],
-                             "LD_LIBRARY_PATH": [Tool.ROOT / "lib"] })
+                paths    = { "PATH"           : [Tool.CNTR_ROOT / "bin"],
+                             "LD_LIBRARY_PATH": [Tool.CNTR_ROOT / "lib"] })
     ]
 
     @Tool.installer("Python")

--- a/example/infra/tools/common.py
+++ b/example/infra/tools/common.py
@@ -1,3 +1,0 @@
-from pathlib import Path
-
-TOOL_ROOT = Path(__file__).absolute().parent.parent.parent.parent / "example.tools"

--- a/example/infra/tools/compilers.py
+++ b/example/infra/tools/compilers.py
@@ -4,22 +4,21 @@ from typing import List
 from blockwork.context import Context, HostArchitecture
 from blockwork.tools import Invocation, Require, Tool, Version
 
-from .common import TOOL_ROOT
 
 @Tool.register()
 class GCC(Tool):
     versions = [
-        Version(location = TOOL_ROOT / "gcc" / "13.1.0",
+        Version(location = Tool.HOST_ROOT / "gcc" / "13.1.0",
                 version  = "13.1.0",
-                paths    = { "PATH"           : [Tool.ROOT / "bin"],
-                             "LD_LIBRARY_PATH": [Tool.ROOT / "lib64"] },
+                paths    = { "PATH"           : [Tool.CNTR_ROOT / "bin"],
+                             "LD_LIBRARY_PATH": [Tool.CNTR_ROOT / "lib64"] },
                 default  = True),
     ]
 
     @Tool.installer("GCC")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://mirrorservice.org/sites/sourceware.org/pub/gcc/releases/gcc-{vernum}/gcc-{vernum}.tar.gz",
             f"tar -xf gcc-{vernum}.tar.gz",
@@ -47,10 +46,10 @@ class GCC(Tool):
 class M4(Tool):
     versions = [
         Version(
-            location=TOOL_ROOT / "m4" / "1.4.19",
+            location=Tool.HOST_ROOT / "m4" / "1.4.19",
             version="1.4.19",
             requires=[Require(GCC, "13.1.0")],
-            paths={"PATH": [Tool.ROOT / "bin"]},
+            paths={"PATH": [Tool.CNTR_ROOT / "bin"]},
             default=True,
         ),
     ]
@@ -58,7 +57,7 @@ class M4(Tool):
     @Tool.installer("M4")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://ftp.gnu.org/gnu/m4/m4-{vernum}.tar.gz",
             f"tar -xf m4-{vernum}.tar.gz",
@@ -81,15 +80,15 @@ class M4(Tool):
 class Flex(Tool):
     versions = [
         Version(
-            location=TOOL_ROOT / "flex" / "2.6.4",
+            location=Tool.HOST_ROOT / "flex" / "2.6.4",
             version="2.6.4",
             requires=[Require(GCC, "13.1.0"),
                       Require(M4, "1.4.19")],
             paths={
-                "PATH": [Tool.ROOT / "bin"],
-                "LD_LIBRARY_PATH": [Tool.ROOT / "lib"],
-                "C_INCLUDE_PATH": [Tool.ROOT / "include"],
-                "CPLUS_INCLUDE_PATH": [Tool.ROOT / "include"],
+                "PATH": [Tool.CNTR_ROOT / "bin"],
+                "LD_LIBRARY_PATH": [Tool.CNTR_ROOT / "lib"],
+                "C_INCLUDE_PATH": [Tool.CNTR_ROOT / "include"],
+                "CPLUS_INCLUDE_PATH": [Tool.CNTR_ROOT / "include"],
             },
             default=True,
         ),
@@ -98,7 +97,7 @@ class Flex(Tool):
     @Tool.installer("Flex")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://github.com/westes/flex/releases/download/v{vernum}/flex-{vernum}.tar.gz",
             f"tar -xf flex-{vernum}.tar.gz",
@@ -121,11 +120,11 @@ class Flex(Tool):
 class Bison(Tool):
     versions = [
         Version(
-            location=TOOL_ROOT / "bison" / "3.8",
+            location=Tool.HOST_ROOT / "bison" / "3.8",
             version="3.8",
             requires=[Require(GCC, "13.1.0"),
                       Require(M4, "1.4.19")],
-            paths={"PATH": [Tool.ROOT / "bin"], "LD_LIBRARY_PATH": [Tool.ROOT / "lib"]},
+            paths={"PATH": [Tool.CNTR_ROOT / "bin"], "LD_LIBRARY_PATH": [Tool.CNTR_ROOT / "lib"]},
             default=True,
         ),
     ]
@@ -133,7 +132,7 @@ class Bison(Tool):
     @Tool.installer("Bison")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://ftp.gnu.org/gnu/bison/bison-{vernum}.tar.gz",
             f"tar -xf bison-{vernum}.tar.gz",
@@ -156,11 +155,11 @@ class Bison(Tool):
 class Autoconf(Tool):
     versions = [
         Version(
-            location=TOOL_ROOT / "autoconf" / "2.71",
+            location=Tool.HOST_ROOT / "autoconf" / "2.71",
             version="2.71",
             requires=[Require(GCC, "13.1.0"),
                       Require(M4, "1.4.19")],
-            paths={"PATH": [Tool.ROOT / "bin"]},
+            paths={"PATH": [Tool.CNTR_ROOT / "bin"]},
             default=True,
         ),
     ]
@@ -168,7 +167,7 @@ class Autoconf(Tool):
     @Tool.installer("Autoconf")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://ftp.gnu.org/gnu/autoconf/autoconf-{vernum}.tar.gz",
             f"tar -xf autoconf-{vernum}.tar.gz",
@@ -191,10 +190,10 @@ class Autoconf(Tool):
 class CMake(Tool):
     versions = [
         Version(
-            location=TOOL_ROOT / "cmake" / "3.27.1",
+            location=Tool.HOST_ROOT / "cmake" / "3.27.1",
             version="3.27.1",
             requires=[Require(GCC, "13.1.0")],
-            paths={"PATH": [Tool.ROOT / "bin"]},
+            paths={"PATH": [Tool.CNTR_ROOT / "bin"]},
             default=True,
         ),
     ]
@@ -203,7 +202,7 @@ class CMake(Tool):
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
         arch_str = ["x86_64", "aarch64"][ctx.host_architecture is HostArchitecture.ARM]
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://github.com/Kitware/CMake/releases/download/v{vernum}/cmake-{vernum}-linux-{arch_str}.sh",
             f"bash ./cmake-{vernum}-linux-aarch64.sh --prefix={tool_dir.as_posix()} --skip-license"
@@ -220,14 +219,14 @@ class CMake(Tool):
 class CCache(Tool):
     versions = [
         Version(
-            location=TOOL_ROOT / "ccache" / "4.8.2",
+            location=Tool.HOST_ROOT / "ccache" / "4.8.2",
             version="4.8.2",
             requires=[Require(GCC, "13.1.0"),
                       Require(Flex, "2.6.4"),
                       Require(Bison, "3.8"),
                       Require(Autoconf, "2.71"),
                       Require(CMake, "3.27.1")],
-            paths={"PATH": [Tool.ROOT]},
+            paths={"PATH": [Tool.CNTR_ROOT]},
             default=True,
         ),
     ]
@@ -235,7 +234,7 @@ class CCache(Tool):
     @Tool.installer("CCache")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://github.com/ccache/ccache/releases/download/v{vernum}/ccache-{vernum}.tar.gz",
             f"tar -xf ccache-{vernum}.tar.gz",
@@ -260,10 +259,10 @@ class CCache(Tool):
 class Help2Man(Tool):
     versions = [
         Version(
-            location=TOOL_ROOT / "help2man" / "1.49.3",
+            location=Tool.HOST_ROOT / "help2man" / "1.49.3",
             version="1.49.3",
             requires=[Require(GCC, "13.1.0")],
-            paths={"PATH": [Tool.ROOT / "bin"]},
+            paths={"PATH": [Tool.CNTR_ROOT / "bin"]},
             default=True,
         ),
     ]
@@ -271,7 +270,7 @@ class Help2Man(Tool):
     @Tool.installer("Help2Man")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet http://mirror.koddos.net/gnu/help2man/help2man-{vernum}.tar.xz",
             f"tar -xf help2man-{vernum}.tar.xz",
@@ -294,10 +293,10 @@ class Help2Man(Tool):
 class GPerf(Tool):
     versions = [
         Version(
-            location=TOOL_ROOT / "gperf" / "3.1",
+            location=Tool.HOST_ROOT / "gperf" / "3.1",
             version="3.1",
             requires=[Require(GCC, "13.1.0")],
-            paths={"PATH": [Tool.ROOT / "bin"]},
+            paths={"PATH": [Tool.CNTR_ROOT / "bin"]},
             default=True,
         ),
     ]
@@ -305,7 +304,7 @@ class GPerf(Tool):
     @Tool.installer("GPerf")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet http://ftp.gnu.org/pub/gnu/gperf/gperf-{vernum}.tar.gz",
             f"tar -xf gperf-{vernum}.tar.gz",
@@ -328,11 +327,11 @@ class GPerf(Tool):
 class Automake(Tool):
     versions = [
         Version(
-            location=TOOL_ROOT / "automake" / "1.16.5",
+            location=Tool.HOST_ROOT / "automake" / "1.16.5",
             version="1.16.5",
             requires=[Require(Autoconf, "2.71"),
                       Require(GCC,      "13.1.0")],
-            paths={"PATH": [Tool.ROOT / "bin"]},
+            paths={"PATH": [Tool.CNTR_ROOT / "bin"]},
             default=True,
         ),
     ]
@@ -340,7 +339,7 @@ class Automake(Tool):
     @Tool.installer("Automake")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://ftp.gnu.org/gnu/automake/automake-{vernum}.tar.gz",
             f"tar -xf automake-{vernum}.tar.gz",
@@ -363,11 +362,11 @@ class Automake(Tool):
 class PkgConfig(Tool):
     versions = [
         Version(
-            location=TOOL_ROOT / "pkgconfig" / "0.29.2",
+            location=Tool.HOST_ROOT / "pkgconfig" / "0.29.2",
             version="0.29.2",
             requires=[Require(Autoconf, "2.71"),
                       Require(GCC,      "13.1.0")],
-            paths={"PATH": [Tool.ROOT / "bin"]},
+            paths={"PATH": [Tool.CNTR_ROOT / "bin"]},
             default=True,
         ),
     ]
@@ -375,7 +374,7 @@ class PkgConfig(Tool):
     @Tool.installer("PkgConfig")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget https://pkgconfig.freedesktop.org/releases/pkg-config-{vernum}.tar.gz",
             f"tar -xf pkg-config-{vernum}.tar.gz",

--- a/example/infra/tools/misc.py
+++ b/example/infra/tools/misc.py
@@ -4,24 +4,23 @@ from typing import List
 from blockwork.tools import Invocation, Require, Tool, Version
 from blockwork.context import Context
 
-from .common import TOOL_ROOT
 from .compilers import GCC
 
 @Tool.register()
 class Python(Tool):
     versions = [
-        Version(location = TOOL_ROOT / "python" / "3.11.4",
+        Version(location = Tool.HOST_ROOT / "python" / "3.11.4",
                 version  = "3.11.4",
                 requires = [Require(GCC, "13.1.0")],
-                paths    = { "PATH"           : [Tool.ROOT / "bin"],
-                             "LD_LIBRARY_PATH": [Tool.ROOT / "lib"] },
+                paths    = { "PATH"           : [Tool.CNTR_ROOT / "bin"],
+                             "LD_LIBRARY_PATH": [Tool.CNTR_ROOT / "lib"] },
                 default  = True),
     ]
 
     @Tool.installer("Python")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://www.python.org/ftp/python/{vernum}/Python-{vernum}.tgz",
             f"tar -xf Python-{vernum}.tgz",
@@ -44,11 +43,11 @@ class Python(Tool):
 @Tool.register()
 class PythonSite(Tool):
     versions = [
-        Version(location = TOOL_ROOT / "python-site" / "3.11.4",
+        Version(location = Tool.HOST_ROOT / "python-site" / "3.11.4",
                 version  = "3.11.4",
-                env      = { "PYTHONUSERBASE": Tool.ROOT },
-                paths    = { "PATH"      : [Tool.ROOT / "bin"],
-                             "PYTHONPATH": [Tool.ROOT / "lib" / "python3.11" / "site-packages"] },
+                env      = { "PYTHONUSERBASE": Tool.CNTR_ROOT },
+                paths    = { "PATH"      : [Tool.CNTR_ROOT / "bin"],
+                             "PYTHONPATH": [Tool.CNTR_ROOT / "lib" / "python3.11" / "site-packages"] },
                 requires = [Require(Python, "3.11.4")],
                 default  = True),
     ]
@@ -82,9 +81,9 @@ class PythonSite(Tool):
 @Tool.register()
 class Make(Tool):
     versions = [
-        Version(location = TOOL_ROOT / "make" / "4.4.1",
+        Version(location = Tool.HOST_ROOT / "make" / "4.4.1",
                 version  = "4.4.1",
-                paths    = { "PATH": [Tool.ROOT / "bin"] },
+                paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] },
                 default  = True),
     ]
 
@@ -95,7 +94,7 @@ class Make(Tool):
     @Tool.installer("Make")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://ftp.gnu.org/gnu/make/make-{vernum}.tar.gz",
             f"tar -xf make-{vernum}.tar.gz",

--- a/example/infra/tools/simulators.py
+++ b/example/infra/tools/simulators.py
@@ -4,27 +4,26 @@ from typing import List
 from blockwork.tools import Invocation, Require, Tool, Version
 from blockwork.context import Context
 
-from .common import TOOL_ROOT
 from .compilers import Autoconf, Bison, CCache, GCC, GPerf, Help2Man, Flex
 
 @Tool.register()
 class IVerilog(Tool):
     versions = [
-        Version(location = TOOL_ROOT / "iverilog" / "12.0",
+        Version(location = Tool.HOST_ROOT / "iverilog" / "12.0",
                 version  = "12.0",
                 requires = [Require(Autoconf, "2.71"),
                             Require(Bison,    "3.8"),
                             Require(GCC,      "13.1.0"),
                             Require(Flex,     "2.6.4"),
                             Require(GPerf,    "3.1")],
-                paths    = { "PATH": [Tool.ROOT / "bin"] },
+                paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] },
                 default  = True),
     ]
 
     @Tool.installer("IVerilog")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version.replace(".", "_")
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://github.com/steveicarus/iverilog/archive/refs/tags/v{vernum}.tar.gz",
             f"tar -xf v{vernum}.tar.gz",
@@ -47,11 +46,11 @@ class IVerilog(Tool):
 @Tool.register()
 class Verilator(Tool):
     versions = [
-        Version(location = TOOL_ROOT / "verilator" / "5.014",
+        Version(location = Tool.HOST_ROOT / "verilator" / "5.014",
                 version  = "5.014",
                 env      = { "VERILATOR_BIN": "../../bin/verilator_bin",
-                             "VERILATOR_ROOT": Tool.ROOT / "share" / "verilator" },
-                paths    = { "PATH": [Tool.ROOT / "bin"] },
+                             "VERILATOR_ROOT": Tool.CNTR_ROOT / "share" / "verilator" },
+                paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] },
                 requires = [Require(Autoconf, "2.71"),
                             Require(Bison,    "3.8"),
                             Require(CCache,   "4.8.2"),
@@ -75,7 +74,7 @@ class Verilator(Tool):
     @Tool.installer("Verilator")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://github.com/verilator/verilator/archive/refs/tags/v{vernum}.tar.gz",
             f"tar -xf v{vernum}.tar.gz",

--- a/example/infra/tools/wave_viewers.py
+++ b/example/infra/tools/wave_viewers.py
@@ -5,18 +5,17 @@ from typing import List
 from blockwork.context import Context
 from blockwork.tools import Invocation, Require, Tool, Version
 
-from .common import TOOL_ROOT
 from .compilers import Automake, GCC, GPerf
 
 @Tool.register()
 class GTKWave(Tool):
     versions = [
-        Version(location = TOOL_ROOT / "gtkwave" / "3.3.116",
+        Version(location = Tool.HOST_ROOT / "gtkwave" / "3.3.116",
                 version  = "3.3.116",
                 requires = [Require(Automake, "1.16.5"),
                             Require(GCC,      "13.1.0"),
                             Require(GPerf,    "3.1")],
-                paths    = { "PATH": [Tool.ROOT / "bin"] },
+                paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] },
                 default  = True),
     ]
 
@@ -50,7 +49,7 @@ class GTKWave(Tool):
     @Tool.installer("GTKWave")
     def install(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
         vernum = version.version
-        tool_dir = Path("/tools") / version.location.relative_to(TOOL_ROOT)
+        tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://github.com/gtkwave/gtkwave/archive/refs/tags/v{vernum}.tar.gz",
             f"tar -xf v{vernum}.tar.gz",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -51,7 +51,7 @@ class TestTools:
                 Version(location = tool_loc,
                         version  = "1.1",
                         env      = { "KEY_A": "VAL_A" },
-                        paths    = { "PATH": [Tool.ROOT / "bin"] })
+                        paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] })
             ]
         # Create an instance
         inst = Widget()
@@ -64,7 +64,7 @@ class TestTools:
         assert inst.versions[0].version == "1.1"
         assert inst.versions[0].location == tool_loc
         assert inst.versions[0].env == { "KEY_A": "VAL_A" }
-        assert inst.versions[0].paths == { "PATH": [Tool.ROOT / "bin"] }
+        assert inst.versions[0].paths == { "PATH": [Tool.CNTR_ROOT / "bin"] }
         assert inst.versions[0].default
         # Check default version pointer
         assert inst.default is inst.versions[0]
@@ -83,7 +83,7 @@ class TestTools:
                 Version(location = tool_loc,
                         version  = "1.1",
                         env      = { "KEY_A": "VAL_A" },
-                        paths    = { "PATH": [Tool.ROOT / "bin"] })
+                        paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] })
             ]
         # Create an instance
         inst = Widget()
@@ -96,7 +96,7 @@ class TestTools:
         assert inst.versions[0].version == "1.1"
         assert inst.versions[0].location == tool_loc
         assert inst.versions[0].env == { "KEY_A": "VAL_A" }
-        assert inst.versions[0].paths == { "PATH": [Tool.ROOT / "bin"] }
+        assert inst.versions[0].paths == { "PATH": [Tool.CNTR_ROOT / "bin"] }
         assert inst.versions[0].default
         # Check default version pointer
         assert inst.default is inst.versions[0]
@@ -118,12 +118,12 @@ class TestTools:
                 Version(location = loc_1_1,
                         version  = "1.1",
                         env      = { "KEY_A": "VAL_A" },
-                        paths    = { "PATH": [Tool.ROOT / "bin"] },
+                        paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] },
                         default  = True),
                 Version(location = loc_1_2,
                         version  = "1.2",
                         env      = { "KEY_A": "VAL_B" },
-                        paths    = { "PATH": [Tool.ROOT / "bin"] })
+                        paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] })
             ]
         # Checks
         inst = Widget()
@@ -300,7 +300,7 @@ class TestTools:
                 Version(location = tool_loc,
                         version  = "1.1",
                         env      = { "KEY_A": "VAL_A" },
-                        paths    = { "PATH": [Tool.ROOT / "bin"] })
+                        paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] })
             ]
             @Tool.action("Widget")
             def do_something(self,
@@ -310,14 +310,14 @@ class TestTools:
                              *args   : List[str]) -> Invocation:
                 return Invocation(
                     version = version,
-                    execute = Tool.ROOT / "bin" / "widget",
+                    execute = Tool.CNTR_ROOT / "bin" / "widget",
                     args    = [an_arg],
                     display = True,
                     binds   = [Path("/a/b/c")],
                 )
             @Tool.action("Widget", default=True)
             def other_thing(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
-                return Invocation(version, execute=Tool.ROOT / "bin" / "thing")
+                return Invocation(version, execute=Tool.CNTR_ROOT / "bin" / "thing")
         # Invoke the 'do_something' action
         act = Widget().get_version("1.1").get_action("do_something")
         assert callable(act)
@@ -325,7 +325,7 @@ class TestTools:
         assert isinstance(ivk, Invocation)
         # Check attributes of the invocation
         assert ivk.version is Widget().get_version("1.1")
-        assert ivk.execute == Tool.ROOT / "bin" / "widget"
+        assert ivk.execute == Tool.CNTR_ROOT / "bin" / "widget"
         assert ivk.args == ["the argument"]
         assert ivk.display
         assert ivk.interactive
@@ -336,7 +336,7 @@ class TestTools:
         ivk_dft = act_dft(DummyContext(), Widget().get_version("1.1"), "abc", "123")
         assert isinstance(ivk_dft, Invocation)
         assert ivk_dft.version is Widget().get_version("1.1")
-        assert ivk_dft.execute == Tool.ROOT / "bin" / "thing"
+        assert ivk_dft.execute == Tool.CNTR_ROOT / "bin" / "thing"
         assert ivk_dft.args == []
         assert not ivk_dft.display
         assert not ivk_dft.interactive
@@ -353,11 +353,11 @@ class TestTools:
                     Version(location = tool_loc,
                             version  = "1.1",
                             env      = { "KEY_A": "VAL_A" },
-                            paths    = { "PATH": [Tool.ROOT / "bin"] })
+                            paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] })
                 ]
                 @Tool.action("Widget")
                 def default(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
-                    return Invocation(version, Tool.ROOT / "bin" / "blah")
+                    return Invocation(version, Tool.CNTR_ROOT / "bin" / "blah")
         assert str(exc.value) == (
             "Cannot register an action called 'default' to tool 'Widget' as it "
             "is a reserved name"
@@ -373,7 +373,7 @@ class TestTools:
                 Version(location = tool_loc,
                         version  = "1.1",
                         env      = { "KEY_A": "VAL_A" },
-                        paths    = { "PATH": [Tool.ROOT / "bin"] })
+                        paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] })
             ]
         # Via the tool
         assert Widget().get_action("blah") is None
@@ -391,11 +391,11 @@ class TestTools:
                 Version(location = tool_loc,
                         version  = "1.1",
                         env      = { "KEY_A": "VAL_A" },
-                        paths    = { "PATH": [Tool.ROOT / "bin"] })
+                        paths    = { "PATH": [Tool.CNTR_ROOT / "bin"] })
             ]
             @Tool.action("Widget")
             def blah(self, ctx: Context, version : Version, *args : List[str]) -> Invocation:
-                return Invocation(version, Tool.ROOT / "bin" / "blah")
+                return Invocation(version, Tool.CNTR_ROOT / "bin" / "blah")
         # Via the tool
         assert Widget().get_action("not_blah") is None
         # Via the version


### PR DESCRIPTION
 * `Tool.HOST_ROOT` introduced
 * `Tool.ROOT` renamed to `Tool.CNTR_ROOT`
 * `!Blockwork` config gains `tools:` and `host_tools:` elements
 * Functions for path resolution based on `Tool.HOST_ROOT` and `Tool.CNTR_ROOT` are added to `Version`
 * Example updated to adopt these variables