### PR TITLE
Misc fixes from real world use

### DIFF
--- a/blockwork/build/interface.py
+++ b/blockwork/build/interface.py
@@ -80,21 +80,21 @@ class Interface(Generic[_RVALUE, _CVALUE]):
         i.connections.append(o)
         o.connections.append(i)
 
-    def resolve_output(self) -> _RVALUE:
+    def resolve_output(self, ctx: "Context") -> _RVALUE:
         """
         Resolve this interface as an output value to pass through to the transform.
         See `resolve` for further details.
         """
         raise NotImplementedError
     
-    def resolve_input(self) -> _RVALUE:
+    def resolve_input(self, ctx: "Context") -> _RVALUE:
         """
         Resolve this interface as an input value to pass through to the transform. 
         See `resolve` for further details.
         """
         raise InterfaceError(f"Interface {self} has no connections and has no way to resolve itself as an input!")
     
-    def resolve(self) -> _RVALUE:
+    def resolve(self, ctx: "Context") -> _RVALUE:
         """
         Resolve this interface to the value that will be passed through to the transform.
         This will internally call:
@@ -109,11 +109,11 @@ class Interface(Generic[_RVALUE, _CVALUE]):
               value that will be seen in the `transform.exec` method.
         """
         if self.direction is InterfaceDirection.Output:
-            return self.resolve_output()
+            return self.resolve_output(ctx)
         if self.connections:
-            return self.connections[0].resolve_output()
+            return self.connections[0].resolve_output(ctx)
         else:
-            return self.resolve_input()
+            return self.resolve_input(ctx)
 
     @classmethod
     def bind_container(cls, ctx: "Context",  container: Container, value: _RVALUE) -> _CVALUE:

--- a/blockwork/build/transform.py
+++ b/blockwork/build/transform.py
@@ -98,9 +98,9 @@ class Transform:
         interface_values: dict[str, Any] = {}
         for name, interfaces in self.interfaces_by_name.items():
             if isinstance(interfaces, Interface):
-                value = interfaces.bind_container(ctx, container, interfaces.resolve())
+                value = interfaces.bind_container(ctx, container, interfaces.resolve(ctx))
             else:
-                value = [interface.bind_container(ctx, container, interface.resolve()) for interface in interfaces]
+                value = [interface.bind_container(ctx, container, interface.resolve(ctx)) for interface in interfaces]
             interface_values[name] = value
 
         tools = ReadonlyNamespace(**tool_instances)

--- a/blockwork/config/base.py
+++ b/blockwork/config/base.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, TYPE_CHECKING
 
-from ..context import Context
+if TYPE_CHECKING:
+    from ..context import Context
 from ..build.interface import FileInterface
 from ..build.transform import Transform
 
@@ -54,10 +55,10 @@ class ElementFileInterface(FileInterface):
     def keys(self):
         yield (self.element._context.unit, self.path)
     
-    def resolve_output(self, ctx: Context):
+    def resolve_output(self, ctx: "Context"):
         return (self.element._context.unit_scratch_path / self.transform.id() / self.path)
     
-    def resolve_input(self, ctx: Context):
+    def resolve_input(self, ctx: "Context"):
         return (self.element._context.unit_project_path / self.path)
 
 

--- a/blockwork/config/base.py
+++ b/blockwork/config/base.py
@@ -14,6 +14,8 @@
 
 from pathlib import Path
 from typing import Iterable
+
+from ..context import Context
 from ..build.interface import FileInterface
 from ..build.transform import Transform
 
@@ -52,10 +54,10 @@ class ElementFileInterface(FileInterface):
     def keys(self):
         yield (self.element._context.unit, self.path)
     
-    def resolve_output(self):
+    def resolve_output(self, ctx: Context):
         return (self.element._context.unit_scratch_path / self.transform.id() / self.path)
     
-    def resolve_input(self):
+    def resolve_input(self, ctx: Context):
         return (self.element._context.unit_project_path / self.path)
 
 

--- a/blockwork/config/parser.py
+++ b/blockwork/config/parser.py
@@ -69,14 +69,19 @@ class Element(Parser):
         if unit == '':
             if (unit := self.unit) is None:
                 raise RuntimeError(f'Require implicit unit for `{target_spec}`, but not in unit context!')
-            
-        # If given empty target, infer here.
-        if target == '':
-            target = target_type.__name__.lower()
-
         # Get the path to the config file
         unit_path = self.ctx.host_root / self.project.units[unit]
-        config_path = unit_path / f"{target}.yaml"
+
+        # The target should be either referring to a directory (in which case the
+        # filename will be implicit based on the target type), or a file.
+        directory_path = unit_path / target / f"{target_type.__name__.lower()}.yaml"
+        file_path = unit_path / f"{target}.yaml"
+        if directory_path.exists():
+            config_path = directory_path
+        elif file_path.exists():
+            config_path = file_path
+        else:
+            raise RuntimeError(f'Config not found for {target_spec} at either `{directory_path}` or `{file_path}`')
 
         # We're evaluating config files recursively going down, keep track
         # of the current unit so we can use it for relative references.


### PR DESCRIPTION
Pass context through to interface resolvers

Catch and discard a noisy warning from typeguard

Improve how config is picked up from the command line