### PR TITLE
Make wf a command group and add example subcommand

### DIFF
--- a/blockwork/__main__.py
+++ b/blockwork/__main__.py
@@ -26,7 +26,6 @@ from .common.registry import Registry
 
 from .bootstrap import Bootstrap
 from .activities import activities
-from .activities.workflow import Workflow
 from .context import Context, HostArchitecture
 from .containers.runtime import Runtime
 from .tools import Tool
@@ -100,7 +99,7 @@ def blockwork(ctx,
     # Trigger registration procedures
     Tool.setup(ctx.obj.host_root, ctx.obj.config.tooldefs)
     Bootstrap.setup(ctx.obj.host_root, ctx.obj.config.bootstrap)
-    Workflow.setup(ctx.obj.host_root, ctx.obj.config.workflows)
+    Registry.setup(ctx.obj.host_root, ctx.obj.config.workflows)
     Registry.setup(ctx.obj.host_root, ctx.obj.config.config)
 
 

--- a/blockwork/activities/__init__.py
+++ b/blockwork/activities/__init__.py
@@ -18,10 +18,10 @@ from .info import info
 from .exec import exec
 from .shell import shell
 from .tools import tool, tools
-from .workflow import workflow
+from .workflow import wf
 
 # List all activities
-activities = (bootstrap, info, exec, shell, tool, tools, workflow)
+activities = (bootstrap, info, exec, shell, tool, tools, wf)
 
 # Lint guard
 assert activities

--- a/blockwork/activities/workflow.py
+++ b/blockwork/activities/workflow.py
@@ -12,33 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
-from typing import cast
 import click
 
-from ..config import parsers
-from ..workflows.workflow import Workflow
 
-from ..context import Context
+@click.group(name='wf')
+def wf() -> None:
+    """
+    Workflow argument group.
 
-@click.command(name='wf')
-@click.option('--project', '-p', type=str, required=True)
-@click.option('--target', '-t', type=str, required=True)
-@click.argument("workflow_name", type=str)
-@click.pass_obj
-def workflow(ctx : Context, project: str, target: str, workflow_name: str) -> None:
-    """ Run a workflow """
-    wf = cast(type[Workflow], Workflow.get_by_name(workflow_name))
-
-    site_parser = parsers.Site(ctx)
-    site_path = ctx.site
-    site_config = site_parser(wf.SITE_TYPE).parse(site_path)
-
-    project_parser = parsers.Project(ctx, site_config)
-    project_path = Path(site_config.projects[project])
-    project_config = project_parser(wf.PROJECT_TYPE).parse(project_path)
-
-    target_parser = parsers.Element(ctx, site_config, project_config)
-    target_config = target_parser.parse_target(target, wf.TARGET_TYPE)
-
-    wf(ctx=ctx, site=site_config, project=project_config, target=target_config).run()
+    In the future we may want to add common options such as --dryrun here
+    """
+    pass

--- a/blockwork/build/interface.py
+++ b/blockwork/build/interface.py
@@ -16,6 +16,8 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Callable, Generic, Hashable, Iterable, Optional, TypeVar, TYPE_CHECKING
 
+from ..common.complexnamespaces import ReadonlyNamespace
+
 from ..common.inithooks import InitHooks
 
 from ..common.singleton import keyed_singleton
@@ -182,12 +184,20 @@ class MetaInterface(Interface[_RVALUE]):
 
 
 class ListInterface(MetaInterface):
-    # List of other interfaces
+    'List of other interfaces'
     def __init__(self, items: Iterable[Interface]) -> None:
         self.items = list(items)
 
     def resolve_meta(self, fn):
         return self.map(fn, self.items)
+    
+class DictInterface(MetaInterface):
+    'Dict of other interfaces'
+    def __init__(self, mapping: dict[str, Interface] | None = None, **interfaces: Interface):
+        self.interfaces = {**(mapping or {}), **interfaces}
+
+    def resolve_meta(self, fn):
+        return ReadonlyNamespace(**{k: fn(v) for k, v in self.interfaces.items()})
 
 
 class FileInterface(Interface[Path]):

--- a/blockwork/build/interface.py
+++ b/blockwork/build/interface.py
@@ -73,12 +73,10 @@ class Interface(Generic[_RVALUE], metaclass=keyed_singleton(inst_key=lambda i: (
         """
         if direction.is_input:
             self.output_transforms.append(transform)
-            transform.input_interfaces.append(self)
         else:
             if self.input_transform:
                 raise RuntimeError(f"Tried to output interface `{self}` from multiple transforms `{self.input_transform}` and `{transform}`")
             self.input_transform = transform
-            transform.output_interfaces.append(self)
 
     def resolve_output(self, ctx: "Context") -> _RVALUE:
         """

--- a/blockwork/build/transform.py
+++ b/blockwork/build/transform.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 from typing import TYPE_CHECKING, Any, Iterable
 
 from ..common.inithooks import InitHooks
@@ -34,6 +35,7 @@ class Transform:
         self._interfaces = {}
 
     @property
+    @functools.lru_cache()
     def output_interfaces(self):
         interfaces: dict[str, Any] = {}
         for name, (direction, interface) in self._interfaces.items():
@@ -42,6 +44,7 @@ class Transform:
         return ReadonlyNamespace(**interfaces)
 
     @property
+    @functools.lru_cache()
     def input_interfaces(self):
         interfaces: dict[str, Any] = {}
         for name, (direction, interface) in self._interfaces.items():
@@ -50,6 +53,7 @@ class Transform:
         return ReadonlyNamespace(**interfaces)
 
     @property
+    @functools.lru_cache()
     def interfaces(self):
         interfaces: dict[str, Any] = {}
         for name, (_direction, interface) in self._interfaces.items():

--- a/blockwork/build/transform.py
+++ b/blockwork/build/transform.py
@@ -13,20 +13,25 @@
 # limitations under the License.
 
 from typing import TYPE_CHECKING, Any, Iterable
+
+from ..common.inithooks import InitHooks
 from ..build.interface import Interface, Direction
 if TYPE_CHECKING:
     from ..tools.tool import Version, Tool, Invocation
     from ..context import Context
 from ..common.complexnamespaces import ReadonlyNamespace
 
+@InitHooks()
 class Transform:
     """
     Base class for transforms.
     """
     tools: list[type["Tool"]] = []
+    _interfaces: dict[str, tuple[Direction, Interface]] 
 
-    def __init__(self):
-        self._interfaces: dict[str, tuple[Direction, Interface]] = {}
+    @InitHooks.pre
+    def init_interfaces(self):
+        self._interfaces = {}
 
     @property
     def output_interfaces(self):

--- a/blockwork/common/complexnamespaces.py
+++ b/blockwork/common/complexnamespaces.py
@@ -37,6 +37,16 @@ class ComplexNamespace(Generic[_NamespaceValue]):
     def __repr__(self):
         return f"namespace({', '.join(f'{k}={v}' for k,v in self.ns.items())})"
 
+    def keys(self):
+        yield from self.ns.keys()
+
+    def values(self):
+        yield from self.ns.values()
+
+    def items(self):
+        yield from self.ns.items()
+
+
 class ReadonlyNamespace(ComplexNamespace[_NamespaceValue]):
     '''
     Namespace where attributes cannot be added or modified post initialisation

--- a/blockwork/common/inithooks.py
+++ b/blockwork/common/inithooks.py
@@ -48,8 +48,8 @@ class InitHooks:
             orig_init_subclass(*args, **kwargs)
             InitHooks._wrap_subcls(subcls_, pre_hooks, post_hooks)
         cls_.__init_subclass__ = classmethod(__init_subclass__)
-
-        return cls_
+        # Finally wrap the cls itself
+        return InitHooks._wrap_subcls(cls_, pre_hooks, post_hooks)
 
     @staticmethod
     def _wrap_subcls(subcls_, pre_hooks, post_hooks):
@@ -57,11 +57,13 @@ class InitHooks:
         # runs our hooks.
         orig_init = subcls_.__init__
         def __init__(self, *args, **kwargs):
-            for hook in pre_hooks:
-                hook(self)
+            if self.__class__ is subcls_:
+                for hook in pre_hooks:
+                    hook(self)
             orig_init(self, *args, **kwargs)
-            for hook in post_hooks:
-                hook(self)
+            if self.__class__ is subcls_:
+                for hook in post_hooks:
+                    hook(self)
         subcls_.__init__ = __init__
         return subcls_
 

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -12,25 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
+from ..common.inithooks import InitHooks
+import click
 import logging
 from pathlib import Path
 from typing import Iterable, cast
 
 from ..config.scheduler import Scheduler
+from ..config import parsers
 
 from ..context import Context
 
 from ..build.interface import Interface
 
 from ..build.transform import Transform
-from ..common.registry import RegisteredClass
-from ..common.singleton import Singleton
 from ..config import base
+from ..activities.workflow import wf
 
 
-class Workflow(RegisteredClass, metaclass=Singleton):
-    """ Base class for workflows """
+@InitHooks()
+class Workflow:
+    """Base class for workflows"""
 
     # Tool root locator
     ROOT : Path = Path("/__tool_root__")
@@ -40,11 +42,33 @@ class Workflow(RegisteredClass, metaclass=Singleton):
     PROJECT_TYPE = base.Project
     TARGET_TYPE = base.Element
 
-    def __init__(self, ctx: Context, site: base.Site, project: base.Project, target: base.Element) -> None:
+    def __init__(self, ctx: Context, project: str, target: str, **options) -> None:
         self.ctx = ctx
-        self.site = site
-        self.project = project
-        self.target = target
+
+        site_parser = parsers.Site(ctx)
+        site_path = ctx.site
+        self.site = site_parser(self.SITE_TYPE).parse(site_path)
+
+        project_parser = parsers.Project(ctx, self.site)
+        project_path = Path(self.site.projects[project])
+        self.project = project_parser(self.PROJECT_TYPE).parse(project_path)
+
+        target_parser = parsers.Element(ctx, self.site, self.project)
+        self.target = target_parser.parse_target(target, self.TARGET_TYPE)
+
+        self.workflow_options = options
+
+    @staticmethod
+    def register():
+        def inner(workflow: "Workflow") -> "Workflow":
+            # This registers the workflow as a subcommand with default options
+            workflow = click.pass_obj(workflow)
+            wf_command = click.command(workflow)
+            wf_command = click.option('--project', '-p', type=str, required=True)(wf_command)
+            wf_command = click.option('--target', '-t', type=str, required=True)(wf_command)
+            wf.add_command(wf_command, name=workflow.__name__.lower())
+            return wf_command
+        return inner
 
     def depth_first_elements(self, element: base.Element) -> Iterable[base.Element]:
         'Recures elements and yields depths first'
@@ -52,6 +76,9 @@ class Workflow(RegisteredClass, metaclass=Singleton):
             yield from self.depth_first_elements(sub_element)
         yield element
 
+    # Note this is run as a post-init hook so subclasses can add attributes
+    # after the init by overriding the method but before the run.
+    @InitHooks.post
     def run(self):
         """
         Run every transform from the configuration.
@@ -67,7 +94,7 @@ class Workflow(RegisteredClass, metaclass=Singleton):
             for transform in element.iter_transforms():
                 element_transforms.append((element, transform))
                 dependency_map[transform] = set()
-                for interface in transform.output_interfaces:
+                for interface in transform.output_interfaces.values():
                     output_interfaces.append(interface)
 
         # We only need to look at output interfaces since an output must
@@ -78,7 +105,7 @@ class Workflow(RegisteredClass, metaclass=Singleton):
                 dependency_map[output_transform].add(input_transform)
 
         # Use the filters to pick out targets
-        targets = (t for e,t in element_transforms if self.transform_filter(t, e))
+        targets = (t for e,t in element_transforms if self.transform_filter(t, e, **self.workflow_options))
 
         # Run everything in order serially
         scheduler = Scheduler(dependency_map, targets=targets)
@@ -93,22 +120,3 @@ class Workflow(RegisteredClass, metaclass=Singleton):
     def transform_filter(self, transform: Transform, element: base.Element) -> bool:
         'Return true for transforms that this workflow is interested in'
         raise NotImplementedError
-
-    @classmethod
-    @property
-    @functools.lru_cache()
-    def name(cls) -> str:
-        return cls.__name__.lower()
-
-    # ==========================================================================
-    # Registry Handling
-    # ==========================================================================
-
-    @classmethod
-    def wrap(cls, workflow : "Workflow") -> "Workflow":
-        if workflow in RegisteredClass.LOOKUP_BY_OBJ[cls]:
-            return workflow
-        else:
-            RegisteredClass.LOOKUP_BY_NAME[cls][workflow.name] = workflow
-            RegisteredClass.LOOKUP_BY_OBJ[cls][workflow] = workflow
-            return workflow

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -60,7 +60,7 @@ class Workflow:
 
     @staticmethod
     def register():
-        def inner(workflow: "Workflow") -> "Workflow":
+        def inner(workflow: type["Workflow"]) -> "Workflow":
             # This registers the workflow as a subcommand with default options
             workflow = click.pass_obj(workflow)
             wf_command = click.command(workflow)

--- a/example/infra/workflows.py
+++ b/example/infra/workflows.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable
+from typing import Optional
+import click
 from blockwork.build.transform import Transform
 from blockwork.config.base import Element
 from blockwork.workflows import Workflow
@@ -21,12 +22,13 @@ from .config.config import Design, Site, Project
 
 
 @Workflow.register()
+@click.option('--match', type=str, default=None)
 class Build(Workflow):
     SITE_TYPE = Site
     PROJECT_TYPE = Project
 
-    def transform_filter(self, transform: Transform, element: Element) -> bool:
-        return True
+    def transform_filter(self, transform: Transform, element: Element, match: Optional[str]) -> bool:
+        return match is None or match.lower() in transform.__class__.__name__.lower()
 
 
 @Workflow.register()


### PR DESCRIPTION
Make wf a click command group so that workflows can set their own options
These are passed back through the transform filter so workflows can do their own filtering

Added *_interfaces properties which return namespaces to transform to make access a little nicer from user code. In particular for if these are used to filter transforms

Added some QOL keys/values/items methods to complexnamespaces