### PR TITLE
Workflows as config

### DIFF
--- a/blockwork/activities/tools.py
+++ b/blockwork/activities/tools.py
@@ -19,7 +19,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from blockwork.tools.tool import ToolActionError
+from ..tools.tool import ToolActionError
 
 from .common import BwExecCommand, ToolMode
 from ..context import Context

--- a/blockwork/bootstrap/tools.py
+++ b/blockwork/bootstrap/tools.py
@@ -18,7 +18,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from blockwork.tools.tool import ToolActionError
+from ..tools.tool import ToolActionError
 
 from ..context import Context
 from ..foundation import Foundation

--- a/blockwork/common/complexnamespaces.py
+++ b/blockwork/common/complexnamespaces.py
@@ -26,6 +26,9 @@ class ComplexNamespace(Generic[_NamespaceValue]):
        
     def __getattr__(self, name) -> _NamespaceValue:
         return self.ns[name]
+    
+    def __getitem__(self, name) -> _NamespaceValue:
+        return self.ns[name]
 
     def __setattr__(self, name: str, value: _NamespaceValue) -> None:
         if self.RO:

--- a/blockwork/config/base.py
+++ b/blockwork/config/base.py
@@ -50,6 +50,8 @@ class Config(metaclass=keyed_singleton(inst_key=lambda i:hash(i))):
         dataclass(kw_only=True, frozen=True, eq=False, repr=False)(cls)
         cls._REGISTRY.register(cls._CONVERTER, tag=cls.YAML_TAG)(cls)
 
+    def __init__(self, *args, **kwargs): ...
+
     def __hash__(self):
         if self.SRC:
             # If we know what the source is - i.e. a file on disc, 

--- a/blockwork/config/base.py
+++ b/blockwork/config/base.py
@@ -76,6 +76,25 @@ class Config(metaclass=keyed_singleton(inst_key=lambda i:hash(i))):
         """
         yield from []
 
+    def config_filter(self, config: "Config"):
+        """
+        Filter configs underneath this which are "interesting".
+
+        For uninteresting configs, we use our own transform filter
+        for transforms underneath them, for interesting configs we
+        use theirs.
+        """
+        return False
+
+    def transform_filter(self, transform: Transform):
+        """
+        Filter transforms underneath this which are "interesting".
+
+        Interesting transforms will be the run targets, uninteresting
+        transforms which are dependencies will also get run.
+        """
+        return True
+
 class Site(Config):
     'Base class for site configuration'
     projects: dict[str, str]

--- a/blockwork/config/base.py
+++ b/blockwork/config/base.py
@@ -86,7 +86,7 @@ class Config(metaclass=keyed_singleton(inst_key=lambda i:hash(i))):
         """
         return False
 
-    def transform_filter(self, transform: Transform):
+    def transform_filter(self, transform: Transform, config: "Config"):
         """
         Filter transforms underneath this which are "interesting".
 

--- a/blockwork/containers/container.py
+++ b/blockwork/containers/container.py
@@ -203,7 +203,7 @@ class Container:
             self.__environment[key] = value
 
     def launch(self,
-               *command    : List[str],
+               *command    : str,
                workdir     : Optional[Path]                 = None,
                interactive : bool                           = False,
                display     : bool                           = False,

--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -18,7 +18,7 @@ import logging
 from collections import defaultdict
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 from ..common.registry import RegisteredClass
 from ..common.singleton import Singleton
@@ -453,12 +453,12 @@ class Invocation:
 
     def __init__(self,
                  version     : Version,
-                 execute     : Path,
-                 args        : Optional[List[Union[str, Path]]] = None,
+                 execute     : Union[Path, str],
+                 args        : Optional[Sequence[Union[str, Path]]] = None,
                  workdir     : Optional[Path] = None,
                  display     : bool = False,
                  interactive : bool = False,
-                 binds       : Optional[List[Union[Path, Tuple[Path, Path]]]] = None,
+                 binds       : Optional[Sequence[Union[Path, Tuple[Path, Path]]]] = None,
                  env         : Optional[Dict[str, str]] = None,
                  path        : Optional[Dict[str, List[str]]] = None) -> None:
         self.version     = version
@@ -471,7 +471,7 @@ class Invocation:
         self.env         = env or {}
         self.path        = path or {}
 
-    def map_args_to_container(self, context : Context) -> List[Union[str, Path]]:
+    def map_args_to_container(self, context : Context) -> List[str]:
         """
         Map all of the arguments of the invocation to be relative to the container.
 

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -141,7 +141,7 @@ class Workflow:
         dependency_map: dict[Transform, set[Transform]] = {}
         targets = []
 
-        for _config, _is_target, transforms, target_transforms in self.gather(root):
+        for _config, transforms, target_transforms in self.gather(root):
             for transform in transforms:
                 dependency_map[transform] = set()
                 for interface in transform.output_interfaces.values():

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -241,4 +241,4 @@ class Workflow(base.Config):
             # This is a really common use-case 
             yield target
         else:
-            raise NotImplementedError
+            yield from []

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial, reduce
-from ..common.complexnamespaces import ReadonlyNamespace
-from ..config.base import Config
+from functools import reduce
+from ..config.base import Config, Project, Site
 import click
 import logging
 from pathlib import Path
-from typing import Iterable, cast
+from typing import Callable, Iterable, Optional, cast
 
 from ..config.scheduler import Scheduler
 from ..config import parsers
@@ -30,172 +29,125 @@ from ..config import base
 from ..activities.workflow import wf
 
 
-class WrapType(click.ParamType):
-    'An wrapped option with some context from creation time'
-    name = "wrap"
-    def __init__(self, option_type, **kwargs):
-        super().__init__()
-        self.option_type = option_type
-        self.kwargs = kwargs
-
-    def convert(self, value, param, ctx):
-        if not isinstance(value, self.option_type):
-            raise TypeError("...")
-        return ReadonlyNamespace(value=value, **self.kwargs)
-
-class Workflow(base.Config):
+class Workflow:
     '''
-    Base class for workflows
-    
-    Workflows are implemented as configuration which can also be generated
-    from a command line. This feature is useful for composition, for example
-    a sim workflow could be run directly on the command line, or used several
-    times in configuration and run via a ci workflow.
+    Wrapper for workflow functions.
 
-    If `from_command` is not customised, the workflow will simply take a
-    --target argument which is expected to point to a workflow config file.
+    Workflows are implemented as functions which are run from the command
+    line and that return a Config object. For example::
+
+        @Workflow("<workflow_name>")
+        @click.option('--match', type=str, required=True)
+        def my_workflow(ctx, match):
+            return Build(match=match)
+
     '''
 
-    # Tool root locator
-    ROOT : Path = Path("/__tool_root__")
+     # Type for Site object
+    SITE_TYPE = Site
 
-    # Type for Site object
-    SITE_TYPE = base.Site
+    def __init__(self, name: str):
+        self.name = name
+        self.project_type = None
+        self.target_type = None
 
-    class Options:
-        'Container for standard workflow options'
-        @staticmethod
-        def project(*, project_type=base.Project):
-            return click.option('--project', '-p', type=WrapType(str, type=project_type), required=True)
+    def with_project(self, typ: Optional[type[Project]]=None):
+        'Convenience method to add a --project option'
+        self.project_type = typ or Project
+        return self
 
-        @staticmethod
-        def target(*, project_type=base.Project, target_type=None):
-            return partial(reduce, lambda f, o: o(f), [
-                click.option('--project', '-p', type=WrapType(str, type=project_type), required=True),
-                click.option('--target', '-t', type=WrapType(str, type=target_type), required=True)
-            ])
-
-
-    # This init only exists to prevent a typechecking issue
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def with_target(self, typ: Optional[type[Config]]=None):
+        'Convenience method to add --project and --target options'
+        self.project_type = self.project_type or Project
+        self.target_type = typ or Config
+        return self
 
     @classmethod
-    @Options.target()
-    def from_command(cls, project, target):
-        '''
-        Create this workflow object from a command.
-
-        This should be implemented in subclass workflows which need
-        to add any custom argument parsing using click, for example::
-
-            @classmethod
-            @click.option('--match', type=str, default=None)
-            def from_command(cls, target, match):
-                return cls(target=target, match=match)
-        '''
-        return target
-    
-
-    @classmethod
-    def _run_command(cls, ctx, project=None, target=None, *args, **kwargs):
-        '''
-        Internally called method to run a workflow from the command line.
-        '''
+    def parse_site(cls, ctx) -> Site:
         SITE_TYPE = cls.SITE_TYPE
         site_parser = parsers.Site(ctx)
         site_path = ctx.site
-        site_config = site_parser(SITE_TYPE).parse(site_path)
+        return site_parser(SITE_TYPE).parse(site_path)
 
-        if project:
-            project_parser = parsers.Project(ctx, site_config)
-            project_path = Path(site_config.projects[project.value])
-            project_config = project_parser(project.type).parse(project_path)
-            kwargs['project'] = project_config
+    @classmethod
+    def parse_project(cls, ctx, site: Site, project: str, typ: type) -> Project:
+        'Parse a project option using the given site'
+        project_parser = parsers.Project(ctx, site)
+        project_path = Path(site.projects[project])
+        return project_parser(typ).parse(project_path)
 
-            if target:
-                target_parser = parsers.Element(ctx, site_config, project_config)
-                # If target type not provided assume we're pointing to a workflow file itself
-                target_type = target.type or cls
-                target_config = target_parser.parse_target(target.value, target_type)
-                kwargs['target'] = target_config
+    @classmethod
+    def parse_target(cls, ctx, site: Site, project: Project, target:str, typ: type) -> base.Element:
+        'Parse a target option using the given site and project'
+        target_parser = parsers.Element(ctx, site, project)
+        # If target type not provided assume we're pointing to a workflow file itself
+        return target_parser.parse_target(target, typ)
 
-        inst = cls.from_command(*args, **kwargs)
-        inst._run(ctx)
+    def __call__(self, fn: Callable[..., Config]) -> Callable[..., None]:
 
-    def __init_subclass__(cls, *args, **kwargs):
-        '''
-        Registers the workflow as a click subcommand with some default 
-        arguments attached.
+        @click.command()
+        @click.pass_obj
+        def command(ctx, project=None, target=None, *args, **kwargs):
+            site = self.parse_site(ctx)
+            if project:
+                kwargs['project'] = self.parse_project(ctx, site, project, self.project_type)
+                if target:
+                    kwargs['target'] = self.parse_target(ctx, site, kwargs['project'], target, self.target_type)
 
-        What this actually does is a bit of a hack, but it does hide the
-        complexity from user code effectively, it:
-            - pulls the workflow options from the `from_command` method
-            - attaches them to the internal `_run_command` method
-            - registers the internal `_run_command` method as a sub command
+            inst = fn(ctx, *args, **kwargs)
+            self._run(ctx, inst)
 
-        '''
-        super().__init_subclass__(*args, **kwargs)
-        if getattr(cls.from_command, '__self__', None) is not cls:
-            raise RuntimeError("from_command must be classmethod")
-        
-        run_command = cls._run_command
-        run_command = click.pass_obj(run_command)
-        run_command = click.command(run_command)
+        option_fns = []
+        if self.project_type:
+            option_fns.append(click.option('--project', '-p', type=str, required=True))
+        if self.target_type:
+            option_fns.append(click.option('--target', '-t', type=str, required=True))
 
-        # Inherit params from from_command
-        run_command.params += getattr(cls.from_command, '__click_params__', [])
+        # Apply the additional options
+        command = reduce(lambda f, o: o(f), option_fns, command)            
 
-        cls._run_command = run_command
-        wf.add_command(cls._run_command, name=cls.__name__.lower())
+        # This is a little horrible but this means click options
+        # can be added before or after the workflow decorator
+        command.params += getattr(fn, '__click_params__', [])
 
-    def _pick(self) -> tuple[list[Transform], list[Transform]]:
-        '''
-        Internally called method to find the transforms and targets
-        from the config tree based on the filter methods.
-        '''
-        workflows = []
-        transforms = []
-        config_by_transform = {}
-        targets = []
+        wf.add_command(command, name=self.name)
+        return command
     
-        done = set()
-        for config in self.depth_first_config(self):
-            # Only process each config once
-            if config in done:
-                continue
-            done.add(config)
 
-            if isinstance(config, Workflow):
-                if self.workflow_filter(config):
-                    workflows.append(config)
+    def gather(self, config: Config) -> Iterable[tuple[Config, list[Transform], list[Transform]]]:
+        '''
+        Iterate over the tree of configs gathering "interesting" transforms.
+        
+        yields [the config, its transforms, its target transforms]
+        '''
+        for child_config in config.iter_config():
+            for desc, transforms, target_transforms in self.gather(child_config):
+                if config.config_filter(desc):
+                    target_transforms = target_transforms
+                else:
+                    target_transforms = list(filter(config.transform_filter, target_transforms))
+                yield desc, transforms, target_transforms
 
-            for transform in config.iter_transforms():
-                config_by_transform[transform] = config
-                transforms.append(transform)
+        transforms = list(config.iter_transforms())
+        target_transforms = list(filter(config.transform_filter, transforms))
+        yield (config, transforms, target_transforms)
 
-        for transform in transforms:
-            config = config_by_transform[transform]
-            if any(wf.transform_filter(transform, config) for wf in workflows):
-                targets.append(transform)
-
-        return transforms, targets
-
-
-    def _run(self, ctx):
+    def _run(self, ctx, root: Config):
         '''
         Internally called method to run the workflow
         '''
         # Join interfaces together and get transform dependencies
         output_interfaces: list[Interface] = []
         dependency_map: dict[Transform, set[Transform]] = {}
-        transforms, targets = self._pick()
+        targets = []
 
-        for transform in transforms:
-            dependency_map[transform] = set()
-            for interface in transform.output_interfaces.values():
-                output_interfaces.append(interface)
-
+        for _config, _is_target, transforms, target_transforms in self.gather(root):
+            for transform in transforms:
+                dependency_map[transform] = set()
+                for interface in transform.output_interfaces.values():
+                    output_interfaces.append(interface)
+            targets += target_transforms
+            
         # We only need to look at output interfaces since an output must
         # exist in order for a dependency to exist
         for interface in output_interfaces:
@@ -212,33 +164,3 @@ class Workflow(base.Config):
                 logging.info("Running transform: %s", transform)
                 transform.run(ctx)
                 scheduler.finish(transform)
-
-
-
-    def transform_filter(self, transform: Transform, config: base.Config) -> bool:
-        'Return true for transforms that this workflow is interested in'
-        raise NotImplementedError
-    
-    def workflow_filter(self, workflow: "Workflow"):
-        'Return true for sub-workflows that this workflow is interested in'
-        # @ed.kotarski - I'm not sure this is actually useful, but leaving in for now...
-        return True
-
-    def depth_first_config(self, config: base.Config) -> Iterable[base.Config]:
-        'Recures elements and yields depths first'
-        for sub_config in config.iter_config():
-            yield from self.depth_first_config(sub_config)
-        yield config
-
-    def iter_config(self) -> Iterable[Config]:
-        '''
-        Generate config for this workflow.
-        This will be useful to override in cases where config is generated
-        based on command line arguments. For example, if a sim workflow
-        allowed test generation to be specified on the command line.
-        '''
-        if isinstance(target:=getattr(self, 'target', None), Config):
-            # This is a really common use-case 
-            yield target
-        else:
-            yield from []

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -59,12 +59,27 @@ class Workflow(base.Config):
     # Type for Site object
     SITE_TYPE = base.Site
 
+    class Options:
+        'Container for standard workflow options'
+        @staticmethod
+        def project(*, project_type=base.Project):
+            return click.option('--project', '-p', type=WrapType(str, type=project_type), required=True)
+
+        @staticmethod
+        def target(*, project_type=base.Project, target_type=base.Config):
+            return partial(reduce, lambda f, o: o(f), [
+                click.option('--project', '-p', type=WrapType(str, type=project_type), required=True),
+                click.option('--target', '-t', type=WrapType(str, type=target_type), required=True)
+            ])
+
+
     # This init only exists to prevent a typechecking issue
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     @classmethod
-    def from_command(cls, target):
+    @Options.target()
+    def from_command(cls, project, target):
         '''
         Create this workflow object from a command.
 
@@ -78,18 +93,6 @@ class Workflow(base.Config):
         '''
         return cls(target=target)
     
-    class Options:
-        'Container for standard workflow options'
-        @staticmethod
-        def project(*, project_type=base.Project):
-            return click.option('--project', '-p', type=WrapType(str, type=project_type), required=True)
-
-        @staticmethod
-        def target(*, project_type=base.Project, target_type=base.Config):
-            return partial(reduce, lambda f, o: o(f), [
-                click.option('--project', '-p', type=WrapType(str, type=project_type), required=True),
-                click.option('--target', '-t', type=WrapType(str, type=target_type), required=True)
-            ])
 
     @classmethod
     def _run_command(cls, ctx, project=None, target=None, *args, **kwargs):

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import reduce
+from functools import partial, reduce
 from ..config.base import Config, Project, Site
 import click
 import logging
@@ -125,11 +125,13 @@ class Workflow:
                 if config.config_filter(desc):
                     target_transforms = target_transforms
                 else:
-                    target_transforms = list(filter(config.transform_filter, target_transforms))
+                    transform_filter = partial(config.transform_filter, config=desc)
+                    target_transforms = list(filter(transform_filter, target_transforms))
                 yield desc, transforms, target_transforms
 
         transforms = list(config.iter_transforms())
-        target_transforms = list(filter(config.transform_filter, transforms))
+        transform_filter = partial(config.transform_filter, config=config)
+        target_transforms = list(filter(transform_filter, transforms))
         yield (config, transforms, target_transforms)
 
     def _run(self, ctx, root: Config):

--- a/example/bench/test.yaml
+++ b/example/bench/test.yaml
@@ -1,0 +1,5 @@
+!Test
+tests:
+  - !Build
+    target: !Testbench bench
+    match: mako

--- a/example/infra/config/config.py
+++ b/example/infra/config/config.py
@@ -43,7 +43,7 @@ class Design(base.Element):
     sources: list[str]
     transforms: list[Mako] = field(default_factory=list)
 
-    def iter_elements(self):
+    def iter_config(self):
         yield from self.transforms
 
     def iter_transforms(self) -> Iterable[Transform]:
@@ -57,5 +57,5 @@ class Testbench(base.Element):
     bench_python: str
     bench_make: str
 
-    def iter_elements(self):
+    def iter_config(self):
         yield self.design

--- a/example/infra/workflows.py
+++ b/example/infra/workflows.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Optional
-from blockwork.config import base
+from typing import Iterable, Optional, Self
 import click
 from blockwork.build.transform import Transform
 from blockwork.config.base import Config, Element
 from blockwork.workflows import Workflow
 from .transforms.lint import VerilatorLintTransform
-from .config.config import Design, Site, Project
 
 
 

--- a/example/infra/workflows.py
+++ b/example/infra/workflows.py
@@ -12,30 +12,56 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Iterable, Optional
+from blockwork.config import base
 import click
 from blockwork.build.transform import Transform
-from blockwork.config.base import Element
+from blockwork.config.base import Config, Element
 from blockwork.workflows import Workflow
 from .transforms.lint import VerilatorLintTransform
 from .config.config import Design, Site, Project
 
 
-@Workflow.register()
-@click.option('--match', type=str, default=None)
+
 class Build(Workflow):
-    SITE_TYPE = Site
-    PROJECT_TYPE = Project
+    target: Config
+    match: Optional[str]
 
-    def transform_filter(self, transform: Transform, element: Element, match: Optional[str]) -> bool:
-        return match is None or match.lower() in transform.__class__.__name__.lower()
+    @classmethod
+    @Workflow.Options.target()
+    @click.option('--match', type=str, default=None)
+    def from_command(cls, project, target, match):
+        inst = cls(target=target, match=match)
+        return inst
 
+    def transform_filter(self, transform: Transform, element: Element) -> bool:
+        return self.match is None or self.match.lower() in transform.__class__.__name__.lower()
 
-@Workflow.register()
+class Test(Workflow):
+    tests: list[Workflow]
+
+    @classmethod
+    @Workflow.Options.target()
+    def from_command(cls, project, target):
+        tests = [
+            Build(target=target, match='mako')
+        ]
+        return cls(tests=tests)
+
+    def iter_config(self) -> Iterable[Config]:
+        yield from self.tests
+    
+    def transform_filter(self, transform: Transform, config: Config) -> bool:
+        return False
+
 class Lint(Workflow):
-    SITE_TYPE = Site
-    PROJECT_TYPE = Project
-    TARGET_TYPE = Design
+    target: Config
+
+    @classmethod
+    @Workflow.Options.target()
+    def from_command(cls, project, target):
+        inst = cls(target=target)
+        return inst
 
     def transform_filter(self, transform: Transform, element: Element) -> bool:
         return isinstance(transform, VerilatorLintTransform)

--- a/example/infra/workflows.py
+++ b/example/infra/workflows.py
@@ -12,54 +12,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Optional, Self
+from typing import Iterable, Optional
+from blockwork.workflows.workflow import Workflow
 import click
 from blockwork.build.transform import Transform
 from blockwork.config.base import Config, Element
-from blockwork.workflows import Workflow
 from .transforms.lint import VerilatorLintTransform
 
 
 
-class Build(Workflow):
+class Build(Config):
     target: Config
     match: Optional[str]
 
-    @classmethod
-    @Workflow.Options.target()
+    @Workflow("build").with_target()
     @click.option('--match', type=str, default=None)
-    def from_command(cls, project, target, match):
-        inst = cls(target=target, match=match)
-        return inst
+    @staticmethod
+    def from_command(ctx, project, target, match):
+        return Build(target=target, match=match)
 
-    def transform_filter(self, transform: Transform, element: Element) -> bool:
+    def iter_config(self) -> Iterable[Config]:
+        yield self.target
+
+    def transform_filter(self, transform: Transform) -> bool:
         return self.match is None or self.match.lower() in transform.__class__.__name__.lower()
 
-class Test(Workflow):
-    tests: list[Workflow]
 
-    @classmethod
-    @Workflow.Options.target()
-    def from_command(cls, project, target):
+class Test(Config):
+    tests: list[Config]
+
+    @Workflow("test").with_target()
+    @staticmethod
+    def from_command(ctx, project, target):
         tests = [
             Build(target=target, match='mako')
         ]
-        return cls(tests=tests)
+        return Test(tests=tests)
 
     def iter_config(self) -> Iterable[Config]:
         yield from self.tests
     
-    def transform_filter(self, transform: Transform, config: Config) -> bool:
-        return False
+    def config_filter(self, config: Config):
+        return config in self.tests
 
-class Lint(Workflow):
+class Lint(Config):
     target: Config
 
-    @classmethod
-    @Workflow.Options.target()
-    def from_command(cls, project, target):
-        inst = cls(target=target)
-        return inst
+    @Workflow("lint").with_target()
+    @staticmethod
+    def from_command(ctx, project, target):
+        breakpoint()
+        return Lint(target=target)
 
-    def transform_filter(self, transform: Transform, element: Element) -> bool:
+    def transform_filter(self, transform: Transform) -> bool:
         return isinstance(transform, VerilatorLintTransform)
+    
+    def iter_config(self) -> Iterable[Config]:
+        yield self.target

--- a/example/infra/workflows.py
+++ b/example/infra/workflows.py
@@ -34,7 +34,7 @@ class Build(Config):
     def iter_config(self) -> Iterable[Config]:
         yield self.target
 
-    def transform_filter(self, transform: Transform) -> bool:
+    def transform_filter(self, transform: Transform, config: Config) -> bool:
         return self.match is None or self.match.lower() in transform.__class__.__name__.lower()
 
 
@@ -64,7 +64,7 @@ class Lint(Config):
         breakpoint()
         return Lint(target=target)
 
-    def transform_filter(self, transform: Transform) -> bool:
+    def transform_filter(self, transform: Transform, config: Config) -> bool:
         return isinstance(transform, VerilatorLintTransform)
     
     def iter_config(self) -> Iterable[Config]:

--- a/example/infra/workflows.py
+++ b/example/infra/workflows.py
@@ -61,7 +61,6 @@ class Lint(Config):
     @Workflow("lint").with_target()
     @staticmethod
     def from_command(ctx, project, target):
-        breakpoint()
         return Lint(target=target)
 
     def transform_filter(self, transform: Transform, config: Config) -> bool:


### PR DESCRIPTION
Changes workflows quite a lot...

A workflow is now simply a command-wrapped function which takes some arguments and returns some configuration. 

The interesting bits where workflows select transforms from a config have now been moved into configuration itself - with configuration able to hierarchically select what to run.

Configuration can now implement the `transform_filter` and `config_filter` methods. 

As before, `transform_filter` is used to select the target transforms to run (with dependencies of them automatically added). However, this now functions hierarchically and is controlled by the `config_filter`.

The `config_filter` acts upon configuration under the current level, and determines whether the sub-config's transform filter is used, or the current level's transform filter.
