### PR TITLE
fix docker stream read

### DIFF
--- a/blockwork/containers/container.py
+++ b/blockwork/containers/container.py
@@ -351,7 +351,7 @@ class Container:
                     os.system("cls || clear")
             # Otherwise, track the task
             else:
-                for (stream, line) in frames_iter(socket, False):
+                for (stream, line) in frames_iter(socket, tty=False):
                     print(line.decode("utf-8"), end="")
             # Get the result (carries the status code)
             # NOTE: Podman sometimes drops the connection during 'wait()' leading

--- a/blockwork/containers/container.py
+++ b/blockwork/containers/container.py
@@ -24,6 +24,7 @@ import time
 from pathlib import Path
 from threading import Event
 from typing import Dict, List, Optional, Tuple, Union
+from docker.utils.socket import frames_iter
 
 import requests
 
@@ -350,12 +351,8 @@ class Container:
                     os.system("cls || clear")
             # Otherwise, track the task
             else:
-                while True:
-                    line = socket.readline()
-                    if not line:
-                        break
-                    # Output the line, replace bad characters with escape sequences
-                    print(line.decode("utf-8", errors="backslashreplace"), end="")
+                for (stream, line) in frames_iter(socket, False):
+                    print(line.decode("utf-8"), end="")
             # Get the result (carries the status code)
             # NOTE: Podman sometimes drops the connection during 'wait()' leading
             #       to a connection aborted error, so retry the operation until


### PR DESCRIPTION
Seems this is the "correct" way even though it isn't documented anywhere really...

Without:
```
0:main $ bw wf lint -p ex -t top
[09:20:35] INFO     Running transform: <infra.transforms.templating.MakoTransform object at 0x104905410>                                                                                                                               
[09:20:36] INFO     Running transform: <infra.transforms.lint.VerilatorLintTransform object at 0x104905650>                                                                                                                            
\x9d%Error: /project/design/top/counter.sv:20:5: syntax error, unexpected end, expecting TYPE-IDENTIFIER
   20 |     end
      |     ^~~
%Error: Cannot continue
```
With:
```                                                                                         
1:main $ bw wf lint -p ex -t top
[09:20:49] INFO     Running transform: <infra.transforms.templating.MakoTransform object at 0x105e767d0>                                                                                                                               
           INFO     Running transform: <infra.transforms.lint.VerilatorLintTransform object at 0x106c80f50>                                                                                                                            
%Error: /project/design/top/counter.sv:20:5: syntax error, unexpected end, expecting TYPE-IDENTIFIER
   20 |     end
      |     ^~~
%Error: Cannot continue
```