### PR TITLE
Fix meta interface dependencies

### DIFF
--- a/blockwork/build/interface.py
+++ b/blockwork/build/interface.py
@@ -91,10 +91,14 @@ class Interface(Generic[_RVALUE], metaclass=keyed_singleton(inst_key=lambda i: (
         """
         if direction.is_input:
             self.output_transforms.append(transform)
+            # Add to the transforms flat interfaces
+            transform._flat_input_interfaces.append(self)
         else:
             if self.input_transform:
                 raise RuntimeError(f"Tried to output interface `{self}` from multiple transforms `{self.input_transform}` and `{transform}`")
             self.input_transform = transform
+            # Add to the transforms flat interfaces
+            transform._flat_output_interfaces.append(self)
 
     def resolve_output(self, ctx: "Context") -> _RVALUE:
         """

--- a/blockwork/build/transform.py
+++ b/blockwork/build/transform.py
@@ -28,11 +28,19 @@ class Transform:
     Base class for transforms.
     """
     tools: list[type["Tool"]] = []
-    _interfaces: dict[str, tuple[Direction, Interface]] 
+    # Interfaces represents the "pretty" view of interfaces
+    # with meta-interfaces visible for hierarchical access
+    _interfaces: dict[str, tuple[Direction, Interface]]
+    # Flat interfaces represent the raw interfaces with those
+    # nested in meta-interfaces unrolled.
+    _flat_input_interfaces: list[Interface]
+    _flat_output_interfaces: list[Interface]
 
     @InitHooks.pre
     def init_interfaces(self):
         self._interfaces = {}
+        self._flat_input_interfaces = []
+        self._flat_output_interfaces = []
 
     @property
     @functools.lru_cache()
@@ -59,6 +67,16 @@ class Transform:
         for name, (_direction, interface) in self._interfaces.items():
             interfaces[name] = interface
         return ReadonlyNamespace(**interfaces)
+    
+    @property
+    @functools.lru_cache()
+    def real_input_interfaces(self):
+        return self._flat_input_interfaces
+    
+    @property
+    @functools.lru_cache()
+    def real_output_interfaces(self):
+        return self._flat_output_interfaces
 
     def id(self):
         """

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -146,7 +146,7 @@ class Workflow:
         for _config, transforms, target_transforms in self.gather(root):
             for transform in transforms:
                 dependency_map[transform] = set()
-                for interface in transform.output_interfaces.values():
+                for interface in transform.real_output_interfaces:
                     output_interfaces.append(interface)
             targets += target_transforms
             


### PR DESCRIPTION
When setting the dependencies between transforms we aren't currently unrolling meta interfaces, so dependencies do not get created