### PR TITLE
capture stdout to interface

### DIFF
--- a/blockwork/build/transform.py
+++ b/blockwork/build/transform.py
@@ -30,7 +30,7 @@ class Transform:
     tools: list[type["Tool"]] = []
     # Interfaces represents the "pretty" view of interfaces
     # with meta-interfaces visible for hierarchical access
-    _interfaces: dict[str, tuple[Direction, Interface]]
+    _interfaces: dict[str, tuple[Direction, bool, Interface]]
     # Flat interfaces represent the raw interfaces with those
     # nested in meta-interfaces unrolled.
     _flat_input_interfaces: list[Interface]
@@ -46,7 +46,7 @@ class Transform:
     @functools.lru_cache()
     def output_interfaces(self):
         interfaces: dict[str, Any] = {}
-        for name, (direction, interface) in self._interfaces.items():
+        for name, (direction, _host, interface) in self._interfaces.items():
             if direction.is_output:
                 interfaces[name] = interface
         return ReadonlyNamespace(**interfaces)
@@ -55,7 +55,7 @@ class Transform:
     @functools.lru_cache()
     def input_interfaces(self):
         interfaces: dict[str, Any] = {}
-        for name, (direction, interface) in self._interfaces.items():
+        for name, (direction, _host, interface) in self._interfaces.items():
             if direction.is_input:
                 interfaces[name] = interface
         return ReadonlyNamespace(**interfaces)
@@ -64,7 +64,7 @@ class Transform:
     @functools.lru_cache()
     def interfaces(self):
         interfaces: dict[str, Any] = {}
-        for name, (_direction, interface) in self._interfaces.items():
+        for name, (direction, _host, interface) in self._interfaces.items():
             interfaces[name] = interface
         return ReadonlyNamespace(**interfaces)
     
@@ -88,15 +88,15 @@ class Transform:
         """
         return f"{self.__class__.__name__}_{id(self)}"
 
-    def _bind_interfaces(self, direction: Direction, **kwargs: Interface):
+    def _bind_interfaces(self, _direction: Direction, _host: bool=False, **kwargs: Interface):
         for name, interface in kwargs.items():
             # Don't allow the same name to be bound twice
             # Though a single call may bind that name to an array of interfaces.
             if name in self._interfaces:
                 raise RuntimeError(f"Interface already bound with name `{name}`.")
 
-            self._interfaces[name] = (direction, interface)
-            interface._bind_transform(self, direction)
+            self._interfaces[name] = (_direction, _host, interface)
+            interface._bind_transform(self, _direction)
 
     def bind_outputs(self, **interface: Interface):
         """
@@ -107,7 +107,19 @@ class Transform:
         may be supplied. Resolved values will be passed through to the execute
         method accordingly as a single value or array of values.
         """
-        return self._bind_interfaces(Direction.Output, **interface)
+        return self._bind_interfaces(Direction.Output, False, **interface)
+    
+    def bind_host_outputs(self, **interface: Interface):
+        """
+        Attach interfaces to this transform by name as outputs. The 
+        supplied names can be used to refer the interfaces in `execute`.
+
+        Host outputs are special in that they resolve as paths on 
+        the host within the execute method. This is sometimes useful if
+        an output file needs to be created from the execute method itself 
+        rather than from within a container.
+        """
+        return self._bind_interfaces(Direction.Output, True, **interface)
 
     def bind_inputs(self, **interface: Interface):
         """
@@ -118,7 +130,7 @@ class Transform:
         may be supplied. Resolved values will be passed through to the execute
         method accordingly as a single value or array of values.
         """
-        return self._bind_interfaces(Direction.Input, **interface)
+        return self._bind_interfaces(Direction.Input, False, **interface)
 
     def run(self, ctx: "Context"):
         """Run the transform in a container."""
@@ -136,8 +148,11 @@ class Transform:
 
         # Bind interfaces to container
         interface_values: dict[str, Any] = {}
-        for name, (direction, interface) in self._interfaces.items():
-            interface_values[name] = interface.resolve_container(ctx, container, direction)
+        for name, (direction, host, interface) in self._interfaces.items():
+            if host:
+                interface_values[name] = interface.resolve(ctx)
+            else:
+                interface_values[name] = interface.resolve_container(ctx, container, direction)
 
         tools = ReadonlyNamespace(**tool_instances)
         iface = ReadonlyNamespace(**interface_values)

--- a/blockwork/containers/common.py
+++ b/blockwork/containers/common.py
@@ -23,7 +23,7 @@ import termios
 import tty
 from socket import SocketIO
 from threading import Event, Thread
-from typing import List, Optional, Tuple
+from typing import List, Optional, TextIO, Tuple
 
 @contextlib.contextmanager
 def get_raw_input():
@@ -63,7 +63,7 @@ def get_raw_input():
         termios.tcsetattr(stdin, termios.TCSADRAIN, orig_termios)
         fcntl.fcntl(sys.stdin, fcntl.F_SETFL, orig_fcntl)
 
-def read_stream(socket : SocketIO, e_done : Event) -> Thread:
+def read_stream(socket : SocketIO, stdout: TextIO, e_done : Event) -> Thread:
     """ Wrapped thread method to capture from the container STDOUT """
     def _inner(socket, e_done):
         try:
@@ -79,8 +79,8 @@ def read_stream(socket : SocketIO, e_done : Event) -> Thread:
                     # but otherwise we don't get carriage returns
                     buff = buff.replace(b'\n',b'\r\n')
                     if len(buff) > 0:
-                        sys.stdout.write(buff.decode("utf-8", errors='backslashreplace'))
-                        sys.stdout.flush()
+                        stdout.write(buff.decode("utf-8", errors='backslashreplace'))
+                        stdout.flush()
                     else:
                         break
         except BrokenPipeError:

--- a/blockwork/containers/container.py
+++ b/blockwork/containers/container.py
@@ -23,8 +23,8 @@ import tempfile
 import time
 from pathlib import Path
 from threading import Event
-from typing import Dict, List, Optional, Tuple, Union
-from docker.utils.socket import frames_iter
+from typing import Dict, List, Mapping, Optional, TextIO, Tuple, Union
+import docker.utils.socket as socket_utils
 
 import requests
 
@@ -205,13 +205,15 @@ class Container:
 
     def launch(self,
                *command    : str,
-               workdir     : Optional[Path]                 = None,
-               interactive : bool                           = False,
-               display     : bool                           = False,
-               show_detach : bool                           = True,
-               clear       : bool                           = False,
-               env         : Optional[Dict[str, str]]       = None,
-               path        : Optional[Dict[str, List[str]]] = None) -> int:
+               workdir     : Optional[Path]                     = None,
+               interactive : bool                               = False,
+               display     : bool                               = False,
+               show_detach : bool                               = True,
+               clear       : bool                               = False,
+               env         : Optional[Dict[str, str]]           = None,
+               path        : Optional[Mapping[str, List[Path]]] = None,
+               stdout      : Optional[TextIO]                   = None,
+               stderr      : Optional[TextIO]                   = None) -> int:
         """
         Launch a task within the container either interactively (STDIN and STDOUT
         streamed from/to the console) or non-interactively (STDOUT is captured).
@@ -230,8 +232,12 @@ class Container:
         # Check for a command
         if not command:
             raise ContainerError("No command provided to execute")
+        stdout = stdout or sys.stdout
+        stderr = stderr or sys.stderr
         # Disable interactive if not a terminal
-        interactive &= sys.stdout and sys.stdout.isatty()
+        # Note we check stdout rather than stdin because when piping out to
+        # a file, stdin still reports as tty, but stdout does not.
+        interactive &= stdout and stdout.isatty()
         # Pickup default working directory if not set
         workdir = workdir or self.workdir
         # Make sure the local bind paths exist
@@ -343,7 +349,7 @@ class Container:
                     print(">>> Use CTRL+P to detach from container <<<")
                 # Start monitoring for STDIN and STDOUT
                 t_write = write_stream(socket, e_done)
-                t_read  = read_stream(socket, e_done)
+                t_read  = read_stream(socket, stdout, e_done)
                 e_done.wait()
                 t_read.join()
                 t_write.join()
@@ -352,8 +358,16 @@ class Container:
                     os.system("cls || clear")
             # Otherwise, track the task
             else:
-                for (stream, line) in frames_iter(socket, tty=False):
-                    print(line.decode("utf-8"), end="")
+                for (stream, b_line) in socket_utils.frames_iter(socket, tty=False):
+                    line = b_line.decode("utf-8")
+                    if stream == socket_utils.STDOUT:
+                        stdout.write(line)
+                    elif stream == socket_utils.STDERR:
+                        stderr.write(line)
+                    else:
+                        raise RuntimeError(f"Unexpected stream `{stream}` for line `{line}`")
+                stdout.flush()
+                stderr.flush()
             # Get the result (carries the status code)
             # NOTE: Podman sometimes drops the connection during 'wait()' leading
             #       to a connection aborted error, so retry the operation until

--- a/blockwork/foundation.py
+++ b/blockwork/foundation.py
@@ -149,4 +149,6 @@ class Foundation(Container):
                            display=invocation.display,
                            show_detach=False,
                            env=invocation.env,
-                           path=invocation.path)
+                           path=invocation.path,
+                           stdout=invocation.stdout,
+                           stderr=invocation.stderr)

--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -18,7 +18,7 @@ import logging
 from collections import defaultdict
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, TextIO, Tuple, Union
 
 from ..common.registry import RegisteredClass
 from ..common.singleton import Singleton
@@ -459,15 +459,19 @@ class Invocation:
                  workdir     : Optional[Path] = None,
                  display     : bool = False,
                  interactive : bool = False,
+                 stdout      : Optional[TextIO] = None,
+                 stderr      : Optional[TextIO] = None,
                  binds       : Optional[Sequence[Union[Path, Tuple[Path, Path]]]] = None,
                  env         : Optional[Dict[str, str]] = None,
-                 path        : Optional[Dict[str, List[str]]] = None) -> None:
+                 path        : Optional[dict[str, List[Path]]] = None) -> None:
         self.version     = version
         self.execute     = execute
         self.args        = args or []
         self.workdir     = workdir
         self.display     = display
         self.interactive = interactive or display
+        self.stdout      = stdout
+        self.stderr      = stderr
         self.binds       = binds or []
         self.env         = env or {}
         self.path        = path or {}

--- a/example/.bw.yaml
+++ b/example/.bw.yaml
@@ -9,6 +9,7 @@ tooldefs:
 transforms:
   - infra.transforms.lint
   - infra.transforms.templating
+  - infra.transforms.examples
 workflows:
   - infra.workflows
 config:

--- a/example/infra/transforms/examples.py
+++ b/example/infra/transforms/examples.py
@@ -1,0 +1,36 @@
+# Copyright 2023, Blockwork, github.com/intuity/blockwork
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Any
+from blockwork.build import Interface, Transform
+from blockwork.common.complexnamespaces import ReadonlyNamespace
+from blockwork.context import Context
+from blockwork.tools.tool import Version
+from infra.tools.misc import PythonSite
+
+
+class CapturedTransform(Transform):
+    'Transform with stdout captured to a file interface'
+    tools = [PythonSite]
+
+    def __init__(self, output: Interface[Path]):
+        super().__init__()
+        self.bind_host_outputs(output=output)
+
+    def execute(self, ctx: Context, tools: ReadonlyNamespace[Version], iface: ReadonlyNamespace[Any]):
+        with iface.output.open(mode='w') as stdout:
+            inv = tools.pythonsite.get_action("run")(ctx, "-c", "print('hello interface')")
+            inv.stdout = stdout
+            yield inv

--- a/example/infra/workflows.py
+++ b/example/infra/workflows.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from typing import Iterable, Optional
+from blockwork.build.interface import FileInterface
 from blockwork.workflows.workflow import Workflow
 import click
 from blockwork.build.transform import Transform
-from blockwork.config.base import Config, Element
+from blockwork.config.base import Config
+from .transforms.examples import CapturedTransform
 from .transforms.lint import VerilatorLintTransform
 
 
@@ -54,6 +57,9 @@ class Test(Config):
     
     def config_filter(self, config: Config):
         return config in self.tests
+    
+    def iter_transforms(self) -> Iterable[Transform]:
+        yield CapturedTransform(output=FileInterface(Path('./captured_stdout')))
 
 class Lint(Config):
     target: Config


### PR DESCRIPTION
Add an option to invocations which will redirect stdout and/or stderr
These can be used in conjuction with host interfaces to capture stdout to a file interface