### PR TITLE
Conditionally map host paths

### DIFF
--- a/blockwork/activities/tools.py
+++ b/blockwork/activities/tools.py
@@ -95,6 +95,8 @@ def tool(ctx         : Context,
         raise Exception(f"No action known for '{action}' on tool {tool}")
     # Run the action and forward the exit code
     container = Foundation(ctx, hostname=f"{ctx.config.project}_{tool}_{action}")
+    invocation = act_def(ctx, *runargs)
+    invocation.host = True
     sys.exit(container.invoke(ctx,
-                              act_def(ctx, *runargs),
+                              invocation,
                               readonly=(ToolMode(tool_mode) == ToolMode.READONLY)))

--- a/blockwork/containers/container.py
+++ b/blockwork/containers/container.py
@@ -211,7 +211,7 @@ class Container:
                show_detach : bool                           = True,
                clear       : bool                           = False,
                env         : Optional[Dict[str, str]]       = None,
-               path        : Optional[Dict[str, List[str]]] = None) -> int:
+               path        : Optional[Dict[str, List[Path]]] = None) -> int:
         """
         Launch a task within the container either interactively (STDIN and STDOUT
         streamed from/to the console) or non-interactively (STDOUT is captured).

--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -14,11 +14,14 @@
 
 import functools
 import inspect
+from itertools import chain
 import logging
 from collections import defaultdict
 from enum import StrEnum, auto
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+
+from ..containers.container import Container
 
 from ..common.registry import RegisteredClass
 from ..common.singleton import Singleton
@@ -196,7 +199,7 @@ class Tool(RegisteredClass, metaclass=Singleton):
 
     # Placeholders
     vendor   : Optional[str]           = None
-    versions : Optional[List[Version]] = None
+    versions : Optional[Sequence[Version]] = None
 
     def __init__(self) -> None:
         self.vendor = self.vendor.strip() if isinstance(self.vendor, str) else Tool.NO_VENDOR
@@ -444,6 +447,7 @@ class Invocation:
     :param workdir:     Working directory within the container
     :param display:     Whether to forward X11 display (forces interactive mode)
     :param interactive: Whether to attach an interactive shell
+    :param host:        Whether to detect and bind host paths
     :param binds:       Paths to bind into the container from the host. Can be
                         provided as a single path in which case the container
                         path will be inferred, or as a tuple of a host path and
@@ -459,6 +463,7 @@ class Invocation:
                  workdir     : Optional[Path] = None,
                  display     : bool = False,
                  interactive : bool = False,
+                 host        : bool = False,
                  binds       : Optional[Sequence[Union[Path, Tuple[Path, Path]]]] = None,
                  env         : Optional[Dict[str, str]] = None,
                  path        : Optional[Dict[str, List[str]]] = None) -> None:
@@ -468,31 +473,51 @@ class Invocation:
         self.workdir     = workdir
         self.display     = display
         self.interactive = interactive or display
+        self.host        = host
         self.binds       = binds or []
         self.env         = env or {}
         self.path        = path or {}
 
-    def map_args_to_container(self, context : Context) -> List[str]:
+    def bind_and_map(self, context: Context, container: Container):
         """
-        Map all of the arguments of the invocation to be relative to the container.
+        Map host paths to container paths (if applicable) and bind paths to container
 
         :param context: Context object
+        :param container: Container to map to
         :returns:       List of mapped arguments
         """
         args = []
-        for arg in self.args:
-            # If this is a string, but appears to be a relative path, convert it
-            if isinstance(arg, str) and (as_path := (Path.cwd() / arg)).exists():
-                arg = as_path
-            # For path arguments, check they will be accessible in the container
-            if isinstance(arg, Path):
-                try:
-                    c_path = context.map_to_container(arg.absolute())
-                    args.append(c_path.as_posix())
-                except ContextHostPathError:
-                    logging.debug(f"Assuming '{arg}' is a container-relative path")
-                    args.append(arg.as_posix())
-            # Otherwise, just pass through the argument
+        binds = []
+
+        if self.host:
+            # Identify all host paths that need to be bound in
+            for arg in self.args:
+                # If this is a string, but appears to be a relative path, convert it
+                if isinstance(arg, str) and (as_path := (Path.cwd() / arg)).exists():
+                    arg = as_path
+                # For path arguments, check they will be accessible in the container
+                if isinstance(arg, Path):
+                    try:
+                        c_path = context.map_to_container(arg.absolute().resolve())
+                        args.append(c_path.as_posix())
+                        binds.append((arg, context.map_to_container(arg)))
+                    except ContextHostPathError:
+                        logging.debug(f"Assuming '{arg}' is a container-relative path")
+                        args.append(arg.as_posix())
+
+                # Otherwise, just pass through the argument
+                else:
+                    args.append(arg)
+
+        # Bind requested files/folders to relative paths
+        for entry in chain(self.binds, binds):
+            if isinstance(entry, Path):
+                h_path = entry
+                h_path = h_path.absolute()
+                c_path = context.map_to_container(h_path)
             else:
-                args.append(arg)
+                h_path, c_path = entry
+                h_path = h_path.absolute()
+            container.bind(h_path, c_path, False)
+
         return args


### PR DESCRIPTION
Adds an option to invocations to determine whether args that look like host paths should be automatically mapped into the container. This can then be set when calling tools directly from the command line, or omitted if not.

