### PR TITLE
Put timestamp in paths

### DIFF
--- a/blockwork/build/caching.py
+++ b/blockwork/build/caching.py
@@ -66,7 +66,7 @@ class Cache(ABC):
         across caching schemes so consistency checks can be performed.
         '''
         if not path.exists():
-            raise RuntimeError
+            raise RuntimeError(f"Tried to hash a path that does not exist `{path}`")
         if path.is_dir():
             content_hash = hashlib.md5('<dir>'.encode('utf8'))
             for item in sorted(os.listdir(path)):

--- a/blockwork/context.py
+++ b/blockwork/context.py
@@ -20,6 +20,7 @@ from enum import StrEnum, auto
 from pathlib import Path
 import sys
 from typing import Optional, TYPE_CHECKING
+from datetime import datetime
 
 if TYPE_CHECKING:
     from .build.caching import Cache
@@ -66,6 +67,7 @@ class Context:
         self.__file      = cfg_file
         self.__host_root = self.locate_root(root or Path.cwd())
         self.__host_arch = HostArchitecture.identify()
+        self.__timestamp = datetime.now().strftime('D%Y%m%dT%H%M%S')
 
     @property
     def host_architecture(self) -> HostArchitecture:
@@ -204,6 +206,10 @@ class Context:
     @functools.lru_cache()
     def state(self) -> State:
         return State(self.host_state)
+    
+    @property
+    def timestamp(self) -> str:
+        return self.__timestamp
 
     def map_to_container(self, h_path : Path) -> Path:
         """


### PR DESCRIPTION
All paths under a run will contain a shared timestamp. It is to the second which I think is adequate for now