### PR TITLE
handle symlinks in fileinterface

### DIFF
--- a/blockwork/build/interface.py
+++ b/blockwork/build/interface.py
@@ -275,7 +275,7 @@ class FileInterface(Interface[Path]):
         self.value = Path(value)
 
     def resolve_container(self, ctx: "Context", container: Container, direction: Direction):
-        value = self.resolve(ctx)
+        value = self.resolve(ctx).resolve()
         container_path = ctx.map_to_container(value)
         readonly = direction.is_input
         container.bind(value.parent, container_path.parent, readonly=readonly)


### PR DESCRIPTION
Get the real path before mapping into container