### PR TITLE
Use dataclass_transform to provide better type hints

### DIFF
--- a/blockwork/common/checkeddataclasses.py
+++ b/blockwork/common/checkeddataclasses.py
@@ -31,15 +31,15 @@ class FieldError(TypeError):
         return self.msg
 
 
-F = TypeVar("F", bound=Callable[..., Any])
+FunctionType = TypeVar("FunctionType", bound=Callable[..., Any])
 
 
-class CopySignature(Generic[F]):
-    def __init__(self, target: F) -> None:
+class CopySignature(Generic[FunctionType]):
+    def __init__(self, target: FunctionType) -> None:
         ...
 
-    def __call__(self, wrapped: Callable[..., Any]) -> F:
-        return cast(F, wrapped)
+    def __call__(self, wrapped: Callable[..., Any]) -> FunctionType:
+        return cast(FunctionType, wrapped)
 
 
 DCLS = TypeVar("DCLS")

--- a/blockwork/config/base.py
+++ b/blockwork/config/base.py
@@ -39,7 +39,9 @@ class ConfigConverter(DataclassConverter["Config", "Parser"]):
             return super().construct_mapping(loader, node)
 
 
-@dataclass_transform(kw_only_default=True, frozen_default=True, eq_default=False, field_specifiers=(field,))
+@dataclass_transform(
+    kw_only_default=True, frozen_default=True, eq_default=False, field_specifiers=(field,)
+)
 class Config(metaclass=keyed_singleton(inst_key=lambda i: hash(i))):
     """
     Base class for all config.

--- a/blockwork/config/base.py
+++ b/blockwork/config/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Iterable
+from typing import dataclass_transform
 
 import yaml
 
@@ -38,6 +39,7 @@ class ConfigConverter(DataclassConverter["Config", "Parser"]):
             return super().construct_mapping(loader, node)
 
 
+@dataclass_transform(kw_only_default=True, frozen_default=True, eq_default=False, field_specifiers=(field,))
 class Config(metaclass=keyed_singleton(inst_key=lambda i: hash(i))):
     """
     Base class for all config.


### PR DESCRIPTION
`dataclass_transform` enables type checker to treat our `Config` class as a dataclass factory so that type hints work correctly on fields.

Without:
![image](https://github.com/blockwork-eda/blockwork/assets/17129407/2c546b7a-efff-4167-b816-e960358c7591)

With:
![image](https://github.com/blockwork-eda/blockwork/assets/17129407/6861327c-8792-4a9a-891a-60b3196bd6dd)


