### PR TITLE
Using non-absolute paths during bootstrap

### DIFF
--- a/blockwork/bootstrap/tools.py
+++ b/blockwork/bootstrap/tools.py
@@ -51,7 +51,7 @@ def install_tools(context: Context, last_run: datetime) -> bool:
     for idx, tool in enumerate(resolved):
         tool_id = " ".join(tool.id_tuple)
         tool_file = Path(inspect.getfile(type(tool.tool)))
-        host_loc = tool.get_host_path(context)
+        host_loc = tool.get_host_path(context, absolute=False)
         # Ensure the host file path exists
         host_loc.mkdir(exist_ok=True, parents=True)
         # Select a touch file location, this is used to determine if the tool

--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -150,19 +150,21 @@ class Version:
             except ToolActionError:
                 raise e from None
 
-    def get_host_path(self, ctx: Context) -> Path:
+    def get_host_path(self, ctx: Context, absolute: bool = True) -> Path:
         """
         Expand the location to get the full path to the tool on the host system.
         Substitutes Tool.HOST_ROOT for the 'host_tools' path from Context.
 
-        :param ctx: Context object
-        :returns:   Resolved path
+        :param ctx:      Context object
+        :param absolute: Whether to resolve to an absolute path, flattening any
+                         symlinks in the way
+        :returns:        Resolved path
         """
         if self.location.is_relative_to(Tool.HOST_ROOT):
             path = ctx.host_tools / self.location.relative_to(Tool.HOST_ROOT)
         else:
             path = self.location
-        return path.absolute()
+        return path.absolute() if absolute else path
 
     def get_container_path(self, ctx: Context, path: Path | None = None) -> Path:
         """


### PR DESCRIPTION
Fixing issue where the tool bootstrap operation needs to create touch files but attempts to do this on a resolved symlink rather than the local path.