### PR TITLE
Moving tool touch files into the state directory

### DIFF
--- a/blockwork/bootstrap/tools.py
+++ b/blockwork/bootstrap/tools.py
@@ -52,8 +52,6 @@ def install_tools(context: Context, last_run: datetime) -> bool:
         tool_id = " ".join(tool.id_tuple)
         tool_file = Path(inspect.getfile(type(tool.tool)))
         host_loc = tool.get_host_path(context, absolute=False)
-        # Ensure the host folder path exists
-        host_loc.mkdir(exist_ok=True, parents=True)
         # Select a touch file location, this is used to determine if the tool
         # installation is up to date
         touch_file = context.host_state / host_loc.relative_to(context.host_tools) / Tool.TOUCH_FILE

--- a/blockwork/bootstrap/tools.py
+++ b/blockwork/bootstrap/tools.py
@@ -52,6 +52,8 @@ def install_tools(context: Context, last_run: datetime) -> bool:
         tool_id = " ".join(tool.id_tuple)
         tool_file = Path(inspect.getfile(type(tool.tool)))
         host_loc = tool.get_host_path(context, absolute=False)
+        # Ensure the host folder path exists
+        host_loc.mkdir(exist_ok=True, parents=True)
         # Select a touch file location, this is used to determine if the tool
         # installation is up to date
         touch_file = context.host_state / host_loc.relative_to(context.host_tools) / Tool.TOUCH_FILE

--- a/blockwork/bootstrap/tools.py
+++ b/blockwork/bootstrap/tools.py
@@ -52,11 +52,11 @@ def install_tools(context: Context, last_run: datetime) -> bool:
         tool_id = " ".join(tool.id_tuple)
         tool_file = Path(inspect.getfile(type(tool.tool)))
         host_loc = tool.get_host_path(context, absolute=False)
-        # Ensure the host folder path exists
-        host_loc.mkdir(exist_ok=True, parents=True)
+        # Ensure the parent of the tool's folder exists
+        host_loc.parent.mkdir(exist_ok=True, parents=True)
         # Select a touch file location, this is used to determine if the tool
         # installation is up to date
-        touch_file = context.host_state / host_loc.relative_to(context.host_tools) / Tool.TOUCH_FILE
+        touch_file = context.host_state / "tools" / tool.tool.name / tool.version / Tool.TOUCH_FILE
         touch_file.parent.mkdir(exist_ok=True, parents=True)
         # If the touch file exists and install has been run more recently than
         # the definition file was updated, then skip

--- a/blockwork/bootstrap/tools.py
+++ b/blockwork/bootstrap/tools.py
@@ -51,12 +51,13 @@ def install_tools(context: Context, last_run: datetime) -> bool:
     for idx, tool in enumerate(resolved):
         tool_id = " ".join(tool.id_tuple)
         tool_file = Path(inspect.getfile(type(tool.tool)))
-        host_loc = tool.get_host_path(context)
-        # Ensure the host file path exists
+        host_loc = tool.get_host_path(context, absolute=False)
+        # Ensure the host folder path exists
         host_loc.mkdir(exist_ok=True, parents=True)
         # Select a touch file location, this is used to determine if the tool
         # installation is up to date
-        touch_file = host_loc / Tool.TOUCH_FILE
+        touch_file = context.host_state / host_loc.relative_to(context.host_tools) / Tool.TOUCH_FILE
+        touch_file.parent.mkdir(exist_ok=True, parents=True)
         # If the touch file exists and install has been run more recently than
         # the definition file was updated, then skip
         if touch_file.exists():

--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -150,19 +150,20 @@ class Version:
             except ToolActionError:
                 raise e from None
 
-    def get_host_path(self, ctx: Context) -> Path:
+    def get_host_path(self, ctx: Context, absolute: bool = True) -> Path:
         """
         Expand the location to get the full path to the tool on the host system.
         Substitutes Tool.HOST_ROOT for the 'host_tools' path from Context.
 
-        :param ctx: Context object
-        :returns:   Resolved path
+        :param ctx:      Context object
+        :param absolute: When enabled this will flatten symlinks in the hierarchy
+        :returns:        Resolved path
         """
         if self.location.is_relative_to(Tool.HOST_ROOT):
             path = ctx.host_tools / self.location.relative_to(Tool.HOST_ROOT)
         else:
             path = self.location
-        return path.absolute()
+        return path.absolute() if absolute else path
 
     def get_container_path(self, ctx: Context, path: Path | None = None) -> Path:
         """


### PR DESCRIPTION
While the idea of using touch files is good, having them in the tools directory causes problems if symlinks are used for tool installs