### PR TITLE
Making distributed builds easier

### DIFF
--- a/blockwork/bootstrap/containers.py
+++ b/blockwork/bootstrap/containers.py
@@ -12,23 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from datetime import datetime
-from pathlib import Path
 
-from docker.errors import ImageNotFound
 from rich.console import Console
 
-import blockwork
-
-from ..containers.runtime import Runtime
 from ..context import Context
+from ..foundation import Foundation
 from .bootstrap import Bootstrap
-
-root_dir = Path(blockwork.__path__[0]).absolute()
-cntr_dir = root_dir / "containerfiles"
-
-# === Foundation Container ===
 
 
 @Bootstrap.register()
@@ -37,32 +27,6 @@ def build_foundation(context: Context, last_run: datetime) -> bool:
     Built-in bootstrap action that builds the foundation container using the
     active runtime.
     """
-    host_arch = str(context.host_architecture)
-    defn_file = cntr_dir / "foundation" / f"Containerfile_{host_arch}"
-    with Runtime.get_client() as client:
-        img_tag = f"foundation_{host_arch}_{context.host_root_hash}"
-        # Check if the image exists (in case it was removed manually)
-        try:
-            client.images.get(img_tag)
-        except ImageNotFound:
-            last_run = datetime.min
-        # Check that the container file can be found
-        if not defn_file.exists():
-            raise FileExistsError(f"Foundation {defn_file.name} does not exist at '{defn_file}'!")
-        # Check if the container file is newer than the last run
-        if datetime.fromtimestamp(defn_file.stat().st_mtime) <= last_run:
-            return True
-        # Build the container
-        logging.info(
-            f"Building the foundation container from {defn_file} for "
-            f"{host_arch} architecture - this may take a while..."
-        )
-        with Console().status("Building container...", spinner="arc"):
-            client.images.build(
-                path=defn_file.parent.as_posix(),
-                dockerfile=defn_file.name,
-                tag=img_tag,
-                rm=True,
-            )
-        logging.info("Foundation container built")
-        return False
+    with Console().status("Building container...", spinner="arc"):
+        Foundation(context).build()
+        return True

--- a/blockwork/config/api.py
+++ b/blockwork/config/api.py
@@ -277,7 +277,7 @@ class TransformApi:
         self.api = api.fork(transform=self)
         self.transform = transform
         now = datetime.now().strftime("D%Y%m%dT%H%M%S")
-        self.id = f"{type(transform).__name__}-{now}"
+        self.id = f"{type(transform).__name__}-{now}-{id(transform)}"
 
     def path(self, path: str | Path) -> Path:
         if target := self.api._target:

--- a/example/.bw.yaml
+++ b/example/.bw.yaml
@@ -8,7 +8,7 @@ tooldefs:
   - infra.tools.wave_viewers
 workflows:
   - infra.workflows
-caches:
-  - infra.caches.BasicFileCache
+# caches:
+#   - infra.caches.BasicFileCache
 config:
   - infra.config.config

--- a/poetry.lock
+++ b/poetry.lock
@@ -895,6 +895,17 @@ files = [
 six = ">=1.5"
 
 [[package]]
+name = "pytz"
+version = "2024.1"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"},
+    {file = "pytz-2024.1.tar.gz", hash = "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812"},
+]
+
+[[package]]
 name = "pywin32"
 version = "306"
 description = "Python for Window Extensions"
@@ -1327,4 +1338,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "89d4d3af044331ca47cf14ed1f26ac6b6bc945514df78da799bee835cadb1a7f"
+content-hash = "de1122c738f3ba009768c259205617a0dbaba6d99df6724b42d8c390c518eeec"

--- a/poetry.lock
+++ b/poetry.lock
@@ -275,13 +275,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.13.3"
+version = "3.14.0"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.13.3-py3-none-any.whl", hash = "sha256:5ffa845303983e7a0b7ae17636509bc97997d58afeafa72fb141a17b152284cb"},
-    {file = "filelock-3.13.3.tar.gz", hash = "sha256:a79895a25bbefdf55d1a2a0a80968f7dbb28edcd6d4234a0afb3f37ecde4b546"},
+    {file = "filelock-3.14.0-py3-none-any.whl", hash = "sha256:43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f"},
+    {file = "filelock-3.14.0.tar.gz", hash = "sha256:6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"},
 ]
 
 [package.extras]
@@ -1327,4 +1327,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "a351daf4b07fcbe1a2569fdb90fd5d976e18913d9e073d02055d51ec57770211"
+content-hash = "89d4d3af044331ca47cf14ed1f26ac6b6bc945514df78da799bee835cadb1a7f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ typeguard = "^4.1"
 rich = "^13.3.4"
 poethepoet = "^0.20.0"
 ordered-set = "^4.1.0"
+filelock = "^3.14.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ rich = "^13.3.4"
 poethepoet = "^0.20.0"
 ordered-set = "^4.1.0"
 filelock = "^3.14.0"
+pytz = "^2024.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"


### PR DESCRIPTION
A few tweaks to make it easier to manage distributed builds across a number of machines:

 * Automatically building container image if it doesn't exist when an invocation is launched;
 * Using target and project in the scratch path whenever possible;
 * Adding date stamps to scratch paths when target and project not known to lower chance of a collision