### PR TITLE
Improve caching - detect transform changes

### DIFF
--- a/blockwork/__main__.py
+++ b/blockwork/__main__.py
@@ -95,6 +95,17 @@ logging.basicConfig(
     default=None,
     help="Override the scratch folder location",
 )
+@click.option(
+    "--cache/--no-cache",
+    default=True,
+    help="Enable or disable caching",
+)
+@click.option(
+    "--cache-force",
+    is_flag=True,
+    default=False,
+    help="Force caching even for 'targetted' objects",
+)
 def blockwork(
     ctx,
     cwd: str,
@@ -102,9 +113,11 @@ def blockwork(
     verbose_locals: bool,
     quiet: bool,
     pdb: bool,
-    runtime: str | None = None,
-    arch: str | None = None,
-    scratch: str | None = None,
+    runtime: str | None,
+    arch: str | None,
+    scratch: str | None,
+    cache: bool,
+    cache_force: bool,
 ) -> None:
     # Setup post-mortem debug
     DebugScope.current.POSTMORTEM = pdb
@@ -123,6 +136,8 @@ def blockwork(
     ctx.obj = Context(
         root=Path(cwd).absolute() if cwd else None,
         scratch=Path(scratch).absolute() if scratch else None,
+        use_caches=cache,
+        force_cache=cache_force,
     )
     # Set the host architecture
     if arch:

--- a/blockwork/build/caching.py
+++ b/blockwork/build/caching.py
@@ -90,7 +90,7 @@ class PyHasher:
         return self.module_stack[-1]
 
     def is_package(self, module: ModuleType):
-        return hasattr(module, "__path__") and getattr(module, "__file__", None) is None
+        return hasattr(module, "__path__")
 
     def visit_Import(self, node):
         for name in node.names:

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -953,7 +953,7 @@ class Transform:
         }
 
     def _import_hash(self) -> str:
-        return Cache.hash_module(self.__class__.__module__)
+        return Cache.hash_imported_package(self.__class__.__module__)
 
     def _input_hash(self) -> str:
         """

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -952,6 +952,9 @@ class Transform:
             "ifaces": {k: v[1].value for k, v in self._serial_interfaces.items()},
         }
 
+    def _import_hash(self) -> str:
+        return Cache.hash_module(self.__class__.__module__)
+
     def _input_hash(self) -> str:
         """
         Get a hash of the inputs to this transform.
@@ -962,6 +965,7 @@ class Transform:
             return self._cached_input_hash
 
         md5 = hashlib.md5()
+        md5.update(self._import_hash().encode("utf8"))
         for name, (direction, serial) in self._serial_interfaces.items():
             if direction.is_output:
                 continue

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -229,7 +229,7 @@ class Workflow:
             while cache_scheduler.incomplete:
                 for transform in cache_scheduler.schedulable:
                     cache_scheduler.schedule(transform)
-                    if transform not in targets:
+                    if ctx.caching_forced or transform not in targets:
                         if not (
                             dependent_map[transform] - skipped_transforms
                             or dependent_map[transform] - fetched_transforms

--- a/example/.bw.yaml
+++ b/example/.bw.yaml
@@ -8,7 +8,7 @@ tooldefs:
   - infra.tools.wave_viewers
 workflows:
   - infra.workflows
-# caches:
-#   - infra.caches.BasicFileCache
+caches:
+  - infra.caches.BasicFileCache
 config:
   - infra.config.config

--- a/example/infra/caches.py
+++ b/example/infra/caches.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from shutil import copy, copytree
+from shutil import copy, copytree, rmtree
 
 from blockwork.build.caching import Cache
 from blockwork.context import Context
@@ -31,7 +31,7 @@ class BasicFileCache(Cache):
     def store_item(self, content_hash: str, frm: Path) -> bool:
         to = self.content_store / content_hash
         if to.exists():
-            return False
+            return True
         if frm.is_dir():
             copytree(frm, to)
         else:
@@ -39,7 +39,12 @@ class BasicFileCache(Cache):
         return True
 
     def drop_item(self, content_hash: str) -> bool:
-        (self.content_store / content_hash).unlink(missing_ok=True)
+        path = self.content_store / content_hash
+        if path.exists():
+            if path.is_dir():
+                rmtree(path)
+            else:
+                path.unlink()
         return True
 
     def fetch_item(self, content_hash: str, to: Path) -> bool:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -270,6 +270,7 @@ class TestWorkFlowDeps:
 
         class Ctx:
             caches: ClassVar[list[Cache]] = [DummyCache()]
+            caching_forced = False
 
         TransformA, TransformB = self.TFAutoA, self.TFAutoB  # noqa N806
 


### PR DESCRIPTION
Roll in a hash of imported python modules. Python file hashing is based on the AST, which means whitespace and comment changes won't be considered. 

Some limitations:

- Won't detect or consider changes to python library files, or compiled python
- Won't detect manual changes inside pip installed modules 
- Will detect when module versions are updated, or modules are added or removed - but coarsely, it won't consider if the changed modules are actually dependencies or not.
- Python imports outside of the top level (e.g. imported within transform functions) will not become part of the hash. 
  > I can't think how to do this without adding a lot of complexity
- Breakpoints/user-interaction will not prevent caching. This means if you stop on a breakpoint in a transform and continue, the transform results can still be cached, and running again will not stop on the breakpoint.

Still need to:
- Consider when/how to clear old cache
  > Could calculate a score for each entry (perhaps `score = time-to-create / size / time-since-use`) and choose not to cache items below some score threshold, and remove items with the lowest score when the cache reaches a pre-configured size.