### PR TITLE
Use 'self' instead of 'iface' object to access transform interface values in execute

### DIFF
--- a/blockwork/activities/workflow.py
+++ b/blockwork/activities/workflow.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
 import json
-import logging
 from pathlib import Path
 
 import click
@@ -48,8 +46,5 @@ def wf_step(ctx: Context, spec_path: Path):
     #                    executions so that there is a single execution path
     # Reload the serialised workflow step specification
     spec = json.loads(spec_path.read_text(encoding="utf-8"))
-    # Import the relevant transform
-    mod_spec = importlib.import_module(spec["mod"])
-    transform_cls: type[Transform] = getattr(mod_spec, spec["name"])
-    logging.info(f"Running serialised {transform_cls.__name__}")
-    transform_cls._run_serialized(ctx, spec)
+    # Run the relevant transform
+    Transform.run_serialized(ctx, spec)

--- a/blockwork/common/registry.py
+++ b/blockwork/common/registry.py
@@ -18,7 +18,9 @@ from collections import defaultdict
 from collections.abc import Callable
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TypeVar
+
+_RegObj = TypeVar("_RegObj")
 
 
 class RegistryError(Exception):
@@ -54,8 +56,8 @@ class Registry:
         )
 
     @classmethod
-    def register(cls, *_args, **_kwds) -> Any:
-        def _inner(obj: Any) -> Any:
+    def register(cls, *_args, **_kwds) -> Callable[[_RegObj], _RegObj]:
+        def _inner(obj: _RegObj) -> _RegObj:
             cls.wrap(obj)
             return obj
 

--- a/blockwork/containerfiles/foundation/Containerfile_x86
+++ b/blockwork/containerfiles/foundation/Containerfile_x86
@@ -5,12 +5,13 @@ RUN \
     ln -s /usr/bin/blockwork /usr/bin/bw && \
     dnf update -y && \
     dnf install -y epel-release && \
-    dnf install -y which htop nano gtk2 gtk3 gtk3-devel wget xz cpio iputils xterm \
-                   gcc perl bzip2 bzip2-devel tcl tcl-devel tk-devel libnsl \
-                   openssl-devel diffutils libedit-devel readline-devel \
-                   glibc-langpack-en tcsh glibc.i686 libX11 libX11.i686 \
-                   libXext libXext.i686 procps-ng libXft libXft.i686 \
-                   xcb-util xcb-util.i686 xcb-util-wm xcb-util-image xcb-util-keysyms \
+    dnf install -y which htop nano gtk2 gtk3 gtk3-devel wget xz cpio iputils \
+                   xterm gcc perl bzip2 bzip2-devel tcl tcl-devel tk-devel \
+                   libnsl openssl-devel diffutils libedit-devel gmp-devel \
+                   readline-devel glibc-langpack-en tcsh glibc.i686 \
+                   glibc-devel.i686 libgcc.i686 libX11 libX11.i686 libXext \
+                   libXext.i686 procps-ng libXft libXft.i686 xcb-util \
+                   xcb-util.i686 xcb-util-wm xcb-util-image xcb-util-keysyms \
                    xcb-util-renderutil libxkbcommon-x11 mesa-dri-drivers \
                    xorg-x11-utils xorg-x11-xauth libXScrnSaver numactl-libs \
                    mesa-libGL time bc && \

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -20,6 +20,7 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import Field, dataclass, fields
 from dataclasses import field as dc_field
 from enum import Enum, auto
+from functools import reduce
 from pathlib import Path
 from types import EllipsisType, GenericAlias, NoneType
 from typing import (
@@ -989,9 +990,10 @@ class Transform:
     @staticmethod
     def run_serialized(ctx: "Context", spec: TSerialTransform):
         """Run a transform from a spec object"""
-        # Get transform class
+        # Get transform module
         mod = importlib.import_module(spec["mod"])
-        cls: Transform = getattr(mod, spec["name"])
+        # Get class from module (using reduce to navigate module namespacing)
+        cls: Transform = reduce(getattr, spec["name"].split("."), mod)
 
         # Create  a container
         # Note need to do this import here to avoid circular import

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -984,7 +984,7 @@ class Transform:
         """Run the transform in a container."""
         # For now serialize the instance here...
         # later may want to make this a classmethod and pass in
-        Transform._run_serialized(ctx, self.serialize())
+        Transform.run_serialized(ctx, self.serialize())
 
     @staticmethod
     def run_serialized(ctx: "Context", spec: TSerialTransform):

--- a/blockwork/transforms/transforms/file.py
+++ b/blockwork/transforms/transforms/file.py
@@ -9,5 +9,5 @@ class Copy(Transform):
     to: Path = Transform.OUT(init=True, default=...)
     tools = (tools.Bash,)
 
-    def execute(self, ctx, tools, iface):
-        yield tools.bash.get_action("cp")(ctx, frm=iface.frm, to=iface.to)
+    def execute(self, ctx, tools):
+        yield tools.bash.get_action("cp")(ctx, frm=self.frm, to=self.to)

--- a/docs/syntax/transforms.md
+++ b/docs/syntax/transforms.md
@@ -17,9 +17,9 @@ class Copy(Transform):
     frm: Path = Transform.IN()
     to: Path = Transform.OUT(init=True)
 
-    def execute(self, ctx, tools, iface):
+    def execute(self, ctx, tools):
         copy = tools.bash.get_action("cp")
-        yield copy(ctx, frm=iface.frm, to=iface.to)
+        yield copy(ctx, frm=self.frm, to=self.to)
 ```
 
 The first thing to note is that all transforms must inherit from the Transform
@@ -30,43 +30,49 @@ Next we have some class variables.
 ```python
 tools = (Bash,)
 ```
+
 > Here `tools` is a reserved class variable, and should be a a tuple listing the
-tools the transform uses. In this case, the transform uses the Bash tool.
+> tools the transform uses. In this case, the transform uses the Bash tool.
 
 ```python
 frm: Path = Transform.IN()
 ```
+
 > Here we define an inbound interface with the name `frm` and the type `Path`
 
 ```python
 to: Path = Transform.OUT(init=True)
 ```
+
 > Here we define an outbound interface with the name `to`, the type `Path` and
-the field option `init` (see section on interfaces for what that means).
+> the field option `init` (see section on interfaces for what that means).
 
 ```python
 def execute(self, ctx, tools, iface):
 ```
+
 > The execute method defines the process to produce tranform outputs from
-transform inputs. The three arguments are as follows:
+> transform inputs. The three arguments are as follows:
+>
 > 1. `ctx` the Blockwork context object, which has many useful values and
+
      methods.
+
 > 2. `tools` the tools that are mapped into the container
 > 3. `iface` the values provided by the interfaces, mapped into the container.
-
 
 ```python
 copy = tools.bash.get_action("cp")
 ```
+
 > Retrieves an action named `cp` from the bash tool
 
 ```python
 yield copy(ctx, frm=iface.frm, to=iface.to)
 ```
+
 > Reads the values from the `frm` and `to` interfaces, and passes them through
-to the copy action. Actions must be yielded in order to run.
-
-
+> to the copy action. Actions must be yielded in order to run.
 
 ## Basic Use
 
@@ -80,10 +86,10 @@ tf.run(ctx)
 
 ## Interfaces
 
-Interfaces are defined with a *name*, a *type*, a *direction*, and *options*.
-The *name* and *direction* are trivial and indicated by the property name, and
+Interfaces are defined with a _name_, a _type_, a _direction_, and _options_.
+The _name_ and _direction_ are trivial and indicated by the property name, and
 the `IN` and `OUT` in `Transform.IN()` and `Transform.OUT()` respectively. The
-*type* and *options* have more depth and will be the focus of this
+_type_ and _options_ have more depth and will be the focus of this
 section, starting with options.
 
 ### Options
@@ -94,61 +100,70 @@ are best described by example.
 ```python
 files: dict[str, Path] = Transform.IN()
 ```
+
 > An input interface which accepts a dictionary of paths and exposes them
-inside the container
+> inside the container
 
 ```python
 name: str = Transform.IN(env="NAME", default="Blocky")
 ```
+
 > An optional input interface with a default value, and which additionally
-exposes the value in an environment variable `$NAME`.
+> exposes the value in an environment variable `$NAME`.
 
 ```python
 pypath: list[Path] = Transform.IN(env="PYTHONPATH", env_policy=EnvPolicy.APPEND, default_factory=list)
 ```
+
 > An optional input interface with a default which accepts a list of paths
-and exposes them in an environment variable `$PYTHONPATH`. The specified
-`env_policy` indicates the new items should be added to the env of the env
-variable if it is already set, see the section on `IEnv` for detail.
+> and exposes them in an environment variable `$PYTHONPATH`. The specified
+> `env_policy` indicates the new items should be added to the env of the env
+> variable if it is already set, see the section on `IEnv` for detail.
 
 ```python
 result: Path = Transform.OUT()
 ```
+
 > An automatic output interface. The output path will be automatically
-generated based on the transform directory and the interface name. This field
-cannot be set when instancing the transform.
+> generated based on the transform directory and the interface name. This field
+> cannot be set when instancing the transform.
 
 ```python
 result: Path = Transform.OUT(init=True)
 ```
+
 > An initialised output interface. The output path must be specified when the
-transform is instanced. It will not be set automatically if not supplied.
+> transform is instanced. It will not be set automatically if not supplied.
 
 ```python
 result: Path = Transform.OUT(init=True, default=...)
 ```
+
 > An initialisable output interface with an automatic default if a value is not
-specified. The magic value '...' can also be used with input interfaces
-for list and dict types to create an empty list or dict.
+> specified. The magic value '...' can also be used with input interfaces
+> for list and dict types to create an empty list or dict.
 
 ## Types
 
 Interface fields accept the following constant types:
- - `str`
- - `int`
- - `float`
- - `bool`
- - `None`
+
+- `str`
+- `int`
+- `float`
+- `bool`
+- `None`
 
 Along with the additional interface primitives:
- - `Path` (from `pathlib`)
- - `IPath` (`Blockwork.transforms.IPath`)
- - `IEnv` (`Blockwork.transforms.IEnv`)
- - `IFace` (`Blockwork.transforms.IFace`)
+
+- `Path` (from `pathlib`)
+- `IPath` (`Blockwork.transforms.IPath`)
+- `IEnv` (`Blockwork.transforms.IEnv`)
+- `IFace` (`Blockwork.transforms.IFace`)
 
 And the collection types (which can contain any of the above):
- - `list`
- - `dict` (keys must be strings)
+
+- `list`
+- `dict` (keys must be strings)
 
 The constant and collection types are straightforward, they will appear in
 the execute method's `iface` argument exactly as they are specified.
@@ -184,11 +199,11 @@ variables with a name known when the transform is defined. This is useful for
 writing generic and reusable transforms. `IEnv` accepts the following value
 types:
 
- - `str`
- - `int`/`float` (coerced to `str`)
- - `Path`/`IPath` (mapped as above)
- - `None` (ignored)
- - `list` (of any mix of the above)
+- `str`
+- `int`/`float` (coerced to `str`)
+- `Path`/`IPath` (mapped as above)
+- `None` (ignored)
+- `list` (of any mix of the above)
 
 `IEnv` also accepts a `policy` argument which controls it's behaviour if a
 variable is already set (the same behaviour is applied for lists of values).
@@ -208,7 +223,6 @@ reversed `c:b:a`.
 replace
 : Replace the existing value with the new one. Note, when a list of values
 is provided, this will result in only the last value being used.
-
 
 ```Python
 class MyTF(Transform):

--- a/example/infra/tools/compilers.py
+++ b/example/infra/tools/compilers.py
@@ -210,7 +210,8 @@ class CMake(Tool):
         tool_dir = Path("/tools") / version.location.relative_to(Tool.HOST_ROOT)
         script = [
             f"wget --quiet https://github.com/Kitware/CMake/releases/download/v{vernum}/cmake-{vernum}-linux-{arch_str}.sh",
-            f"bash ./cmake-{vernum}-linux-aarch64.sh --prefix={tool_dir.as_posix()} --skip-license",
+            f"bash ./cmake-{vernum}-linux-{arch_str}.sh"
+            " --prefix={tool_dir.as_posix()} --skip-license",
         ]
         return Invocation(
             version=version,

--- a/example/infra/transforms/examples.py
+++ b/example/infra/transforms/examples.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Any
 
 from infra.tools.misc import PythonSite
 
@@ -29,13 +28,8 @@ class CapturedTransform(Transform):
     tools: tuple[Tool, ...] = (PythonSite,)
     output: Path = Transform.OUT(init=True, default=...)
 
-    def execute(
-        self,
-        ctx: Context,
-        tools: ReadonlyNamespace[Version],
-        iface: ReadonlyNamespace[Any],
-    ):
-        output = ctx.map_to_host(iface.output)
+    def execute(self, ctx: Context, tools: ReadonlyNamespace[Version]):
+        output = ctx.map_to_host(self.output)
         with output.open(mode="w", encoding="utf-8") as stdout:
             inv = tools.pythonsite.get_action("run")(ctx, "-c", "print('hello interface')")
             inv.stdout = stdout

--- a/example/infra/transforms/lint.py
+++ b/example/infra/transforms/lint.py
@@ -23,7 +23,7 @@ class VerilatorLintTransform(Transform):
     tools = (Verilator,)
     design: DesignInterface = Transform.IN()
 
-    def execute(self, ctx, tools, iface):
+    def execute(self, ctx, tools):
         yield tools.verilator.get_action("run")(
-            ctx, "--lint-only", "-Wall", *iface.design["sources"]
+            ctx, "--lint-only", "-Wall", *self.design["sources"]
         )

--- a/example/infra/transforms/templating.py
+++ b/example/infra/transforms/templating.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import Any
 
 from blockwork.common.complexnamespaces import ReadonlyNamespace
 from blockwork.context import Context
@@ -28,15 +27,10 @@ class MakoTransform(Transform):
     template: Path = Transform.IN()
     output: Path = Transform.OUT(init=True, default=...)
 
-    def execute(
-        self,
-        ctx: Context,
-        tools: ReadonlyNamespace[Version],
-        iface: ReadonlyNamespace[Any],
-    ):
+    def execute(self, ctx: Context, tools: ReadonlyNamespace[Version]):
         cmd = "from mako.template import Template;"
-        cmd += f"fh = open('{iface.output}', 'w');"
-        cmd += f"fh.write(Template(filename='{iface.template}').render());"
+        cmd += f"fh = open('{self.output}', 'w');"
+        cmd += f"fh.write(Template(filename='{self.template}').render());"
         cmd += "fh.flush();"
         cmd += "fh.close()"
         yield tools.pythonsite.get_action("run")(ctx, "-c", cmd)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -67,18 +67,18 @@ class TestTransforms:
         to: Path = Transform.OUT()
         tools = (tools.Bash,)
 
-        def execute(self, ctx, tools, iface):
+        def execute(self, ctx, tools):
             arbitrary = 1
-            frm = iface.nestedfrm["some"][arbitrary]["complex"]["value"]
-            yield tools.bash.get_action("script")(ctx, f"cat {frm} > {iface.to}")
+            frm = self.nestedfrm["some"][arbitrary]["complex"]["value"]
+            yield tools.bash.get_action("script")(ctx, f"cat {frm} > {self.to}")
 
     def test_input_nest(self, api: ConfigApi):
         text = "input_nest"
         frm = create_with_text(api.ctx.host_scratch / "_/i", text)
 
         tf = self.TFInputNest(nestedfrm={"some": ["arbitrary", {"complex": {"value": Path(frm)}}]})
-
-        tf = transforms.Copy(frm=frm)
+        tf.run(api.ctx)
+        tf = transforms.Copy(frm=tf.to)
         tf.run(api.ctx)
 
         assert tf.to.read_text() == text
@@ -89,9 +89,9 @@ class TestTransforms:
         to2: Path = Transform.OUT()
         tools = (tools.Bash,)
 
-        def execute(self, ctx, tools, iface):
-            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {iface.to1}")
-            yield tools.bash.get_action("script")(ctx, f"echo -n {iface.frm} > {iface.to2}")
+        def execute(self, ctx, tools):
+            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {self.to1}")
+            yield tools.bash.get_action("script")(ctx, f"echo -n {self.frm} > {self.to2}")
 
     def test_simple_field_env(self, api: ConfigApi):
         text = "input_nest"
@@ -111,8 +111,8 @@ class TestTransforms:
         to: Path = Transform.OUT()
         tools = (tools.Bash,)
 
-        def execute(self, ctx, tools, iface):
-            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {iface.to}")
+        def execute(self, ctx, tools):
+            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {self.to}")
 
     class TFComplexFieldEnvPrepend(Transform):
         frm: str = Transform.IN(env="TEST")
@@ -120,8 +120,8 @@ class TestTransforms:
         to: Path = Transform.OUT()
         tools = (tools.Bash,)
 
-        def execute(self, ctx, tools, iface):
-            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {iface.to}")
+        def execute(self, ctx, tools):
+            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {self.to}")
 
     class TFComplexFieldEnvReplace(Transform):
         frm: str = Transform.IN(env="TEST")
@@ -129,8 +129,8 @@ class TestTransforms:
         to: Path = Transform.OUT()
         tools = (tools.Bash,)
 
-        def execute(self, ctx, tools, iface):
-            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {iface.to}")
+        def execute(self, ctx, tools):
+            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {self.to}")
 
     class TFComplexFieldEnvConflict(Transform):
         frm: str = Transform.IN(env="TEST")
@@ -138,8 +138,8 @@ class TestTransforms:
         to: Path = Transform.OUT()
         tools = (tools.Bash,)
 
-        def execute(self, ctx, tools, iface):
-            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {iface.to}")
+        def execute(self, ctx, tools):
+            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {self.to}")
 
     def test_complex_field_env(self, api: ConfigApi):
         text = ["hello", "world"]
@@ -173,18 +173,18 @@ class TestTransforms:
         to3: Path = Transform.OUT()
         tools = (tools.Bash,)
 
-        def execute(self, ctx, tools, iface):
-            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {iface.to1}")
-            yield tools.bash.get_action("script")(ctx, f"echo -n ${iface.frm.key} > {iface.to2}")
-            yield tools.bash.get_action("script")(ctx, f"echo -n {iface.frm.val} > {iface.to3}")
+        def execute(self, ctx, tools):
+            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {self.to1}")
+            yield tools.bash.get_action("script")(ctx, f"echo -n ${self.frm.key} > {self.to2}")
+            yield tools.bash.get_action("script")(ctx, f"echo -n {self.frm.val} > {self.to3}")
 
     class TFComplexArgEnvDeep(Transform):
         frm: Any = Transform.IN()
         to: Path = Transform.OUT()
         tools = (tools.Bash,)
 
-        def execute(self, ctx, tools, iface):
-            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {iface.to}")
+        def execute(self, ctx, tools):
+            yield tools.bash.get_action("script")(ctx, f"echo -n $TEST > {self.to}")
 
     def test_complex_arg_env(self, api: ConfigApi):
         text = "hello world"
@@ -204,8 +204,8 @@ class TestTransforms:
         to: ComplexOutIface = Transform.OUT()
         tools = (tools.Bash,)
 
-        def execute(self, ctx, tools, iface):
-            yield tools.bash.get_action("script")(ctx, f"echo -n {iface.frm} > {iface.to['p0']}")
+        def execute(self, ctx, tools):
+            yield tools.bash.get_action("script")(ctx, f"echo -n {self.frm} > {self.to['p0']}")
 
     def test_complex_out(self, api: ConfigApi):
         text = "hello world"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -328,8 +328,8 @@ class TestWorkFlowDeps:
         result: Path = Transform.OUT()
         tools = (tools.Bash,)
 
-        def execute(self, ctx, tools, iface) -> Iterable[Invocation]:
-            yield tools.bash.get_action("cp")(ctx, frm=iface.file, to=iface.result)
+        def execute(self, ctx, tools) -> Iterable[Invocation]:
+            yield tools.bash.get_action("cp")(ctx, frm=self.file, to=self.result)
 
     def test_multistep(self, api: ConfigApi):
         "Test chain of transforms with multiple steps"


### PR DESCRIPTION
This means:
- Intellisense picks up types correctly
- Execute can call other methods on the transform class

Also fix a couple of issues with x86 bootstrap