### PR TITLE
Remove toolname from action decorator

### DIFF
--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -279,7 +279,7 @@ class Tool(RegisteredClass):
         return default
 
     @classmethod
-    def action(cls, default: bool = False) -> _TWrap:
+    def action(cls, default: bool = False):
         """
         Decorator to mark a Tool method as an action, which can be called either
         by other tools or from the command line.
@@ -288,7 +288,6 @@ class Tool(RegisteredClass):
                             for the tool
         """
 
-        # TYPING
         def _inner(method: _TWrap) -> _TWrap:
             # Annotate the method
             setattr(method, TOOL_ACTION_MARK, True)
@@ -299,7 +298,7 @@ class Tool(RegisteredClass):
         return _inner
 
     @classmethod
-    def installer(cls) -> _TWrap:
+    def installer(cls):
         """
         Special decorator to mark an action that installs the tool by downloading
         it from a central store.

--- a/blockwork/tools/tools/shell.py
+++ b/blockwork/tools/tools/shell.py
@@ -13,10 +13,10 @@ class Bash(Tool):
         ),
     )
 
-    @Tool.action("Bash", default=True)
+    @Tool.action(default=True)
     def script(self, ctx: Context, *script: str) -> Invocation:
         return Invocation(tool=self, execute="bash", args=["-c", " && ".join(script)])
 
-    @Tool.action("Bash")
+    @Tool.action()
     def cp(self, ctx: Context, frm: str, to: str) -> Invocation:
         return Invocation(tool=self, execute="cp", args=["-r", frm, to])

--- a/docs/syntax/tools.md
+++ b/docs/syntax/tools.md
@@ -1,13 +1,13 @@
 As many tools and versions may be declared, the syntax needs to be concise. There
 are three requirements:
 
-1.  The binaries, libraries, and supporting files that form the tool need to be
+ 1. The binaries, libraries, and supporting files that form the tool need to be
     bound into the container instance;
 
-2.  Some environment variables may need to be setup to modify the execution
+ 2. Some environment variables may need to be setup to modify the execution
     behaviour (e.g. `VERILATOR_ROOT`);
 
-3.  Path-type environment variables need to be extended to include the tool's
+ 3. Path-type environment variables need to be extended to include the tool's
     binary and library directories (e.g. `PATH` for binaries and
     `LD_LIBRARY_PATH` for shared object libraries).
 
@@ -31,27 +31,27 @@ class Verilator(Tool):
 
 Working through this example:
 
-- `@Tool.register()` - associates the tool description with Blockwork's internal
-  registry, allowing it to be used in a flow;
+ * `@Tool.register()` - associates the tool description with Blockwork's internal
+   registry, allowing it to be used in a flow;
 
-- `class Verilator(Tool):` - extends from the `Tool` base class and defines the
-  name associated with this definition (e.g. `Verilator`);
+ * `class Verilator(Tool):` - extends from the `Tool` base class and defines the
+   name associated with this definition (e.g. `Verilator`);
 
-- `versions` - defines different named versions of a tool;
+ * `versions` - defines different named versions of a tool;
 
-- Each version is defined by an instance of `Version` where:
+ * Each version is defined by an instance of `Version` where:
 
-  - `location` - identifies the path on the **host** where the tool is installed,
-    this path can use the `Tool.HOST_ROOT` variable that will be resolved to a
-    complete path using the value specified in the [configuration](../config/bw_yaml.md);
+   * `location` - identifies the path on the **host** where the tool is installed,
+     this path can use the `Tool.HOST_ROOT` variable that will be resolved to a
+     complete path using the value specified in the [configuration](../config/bw_yaml.md);
 
-  - `version` - sets the version number for the tool, this is to make it distinct
-    from other declarations;
+   * `version` - sets the version number for the tool, this is to make it distinct
+     from other declarations;
 
-  - `env` - dictionary of variables to append into the container's shell environment;
+   * `env` - dictionary of variables to append into the container's shell environment;
 
-  - `paths` - dictionary of lists, where each list entry is a section to append to
-    a `$PATH`-type variable within the container's shell environment.
+   * `paths` - dictionary of lists, where each list entry is a section to append to
+     a `$PATH`-type variable within the container's shell environment.
 
 !!!note
 
@@ -152,9 +152,9 @@ class PythonSite(Tool):
 
 The `Require` class takes two arguments:
 
-- `tool` - which must carry a `Tool` definition;
-- `version` - which can either be omitted (implicitly selecting the default
-  version) or can be a string identifying a version number.
+ * `tool` - which must carry a `Tool` definition;
+ * `version` - which can either be omitted (implicitly selecting the default
+   version) or can be a string identifying a version number.
 
 ## Actions and Invocations
 

--- a/docs/syntax/tools.md
+++ b/docs/syntax/tools.md
@@ -1,13 +1,13 @@
 As many tools and versions may be declared, the syntax needs to be concise. There
 are three requirements:
 
- 1. The binaries, libraries, and supporting files that form the tool need to be
+1.  The binaries, libraries, and supporting files that form the tool need to be
     bound into the container instance;
 
- 2. Some environment variables may need to be setup to modify the execution
+2.  Some environment variables may need to be setup to modify the execution
     behaviour (e.g. `VERILATOR_ROOT`);
 
- 3. Path-type environment variables need to be extended to include the tool's
+3.  Path-type environment variables need to be extended to include the tool's
     binary and library directories (e.g. `PATH` for binaries and
     `LD_LIBRARY_PATH` for shared object libraries).
 
@@ -31,27 +31,27 @@ class Verilator(Tool):
 
 Working through this example:
 
- * `@Tool.register()` - associates the tool description with Blockwork's internal
-   registry, allowing it to be used in a flow;
+- `@Tool.register()` - associates the tool description with Blockwork's internal
+  registry, allowing it to be used in a flow;
 
- * `class Verilator(Tool):` - extends from the `Tool` base class and defines the
-   name associated with this definition (e.g. `Verilator`);
+- `class Verilator(Tool):` - extends from the `Tool` base class and defines the
+  name associated with this definition (e.g. `Verilator`);
 
- * `versions` - defines different named versions of a tool;
+- `versions` - defines different named versions of a tool;
 
- * Each version is defined by an instance of `Version` where:
+- Each version is defined by an instance of `Version` where:
 
-   * `location` - identifies the path on the **host** where the tool is installed,
-     this path can use the `Tool.HOST_ROOT` variable that will be resolved to a
-     complete path using the value specified in the [configuration](../config/bw_yaml.md);
+  - `location` - identifies the path on the **host** where the tool is installed,
+    this path can use the `Tool.HOST_ROOT` variable that will be resolved to a
+    complete path using the value specified in the [configuration](../config/bw_yaml.md);
 
-   * `version` - sets the version number for the tool, this is to make it distinct
-     from other declarations;
+  - `version` - sets the version number for the tool, this is to make it distinct
+    from other declarations;
 
-   * `env` - dictionary of variables to append into the container's shell environment;
+  - `env` - dictionary of variables to append into the container's shell environment;
 
-   * `paths` - dictionary of lists, where each list entry is a section to append to
-     a `$PATH`-type variable within the container's shell environment.
+  - `paths` - dictionary of lists, where each list entry is a section to append to
+    a `$PATH`-type variable within the container's shell environment.
 
 !!!note
 
@@ -152,9 +152,9 @@ class PythonSite(Tool):
 
 The `Require` class takes two arguments:
 
- * `tool` - which must carry a `Tool` definition;
- * `version` - which can either be omitted (implicitly selecting the default
-   version) or can be a string identifying a version number.
+- `tool` - which must carry a `Tool` definition;
+- `version` - which can either be omitted (implicitly selecting the default
+  version) or can be a string identifying a version number.
 
 ## Actions and Invocations
 
@@ -181,7 +181,7 @@ class GTKWave(Tool):
                 paths    = { "PATH": [Tool.CNTR_ROOT / "src"] }),
     ]
 
-    @Tool.action("GTKWave", default=True)
+    @Tool.action(default=True)
     def view(self,
              ctx      : Context
              wavefile : str,
@@ -233,7 +233,7 @@ is okay, but `/home/fred/outside.vcd` is not.
 
 ## Installers
 
-Blockwork provides a special `@Tool.installer(...)` decorator for registering a
+Blockwork provides a special `@Tool.installer()` decorator for registering a
 specific action for installing a tool's binaries/libraries in some way. How a
 tool is installed (i.e. by downloading or compiling) is up to the action to
 determine.
@@ -257,7 +257,7 @@ class Python(Tool):
                              "LD_LIBRARY_PATH": [Tool.CNTR_ROOT / "lib"] })
     ]
 
-    @Tool.installer("Python")
+    @Tool.installer()
     def install(self, context : Context, *args : List[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(TOOL_ROOT)

--- a/example/infra/tools/compilers.py
+++ b/example/infra/tools/compilers.py
@@ -19,7 +19,7 @@ class GCC(Tool):
         ),
     ]
 
-    @Tool.installer("GCC")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -59,7 +59,7 @@ class M4(Tool):
         ),
     ]
 
-    @Tool.installer("M4")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -98,7 +98,7 @@ class Flex(Tool):
         ),
     ]
 
-    @Tool.installer("Flex")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -135,7 +135,7 @@ class Bison(Tool):
         ),
     ]
 
-    @Tool.installer("Bison")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -169,7 +169,7 @@ class Autoconf(Tool):
         ),
     ]
 
-    @Tool.installer("Autoconf")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -203,7 +203,7 @@ class CMake(Tool):
         ),
     ]
 
-    @Tool.installer("CMake")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         arch_str = ["x86_64", "aarch64"][ctx.host_architecture is HostArchitecture.ARM]
@@ -239,7 +239,7 @@ class CCache(Tool):
         ),
     ]
 
-    @Tool.installer("CCache")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -275,7 +275,7 @@ class Help2Man(Tool):
         ),
     ]
 
-    @Tool.installer("Help2Man")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -309,7 +309,7 @@ class GPerf(Tool):
         ),
     ]
 
-    @Tool.installer("GPerf")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -343,7 +343,7 @@ class Automake(Tool):
         ),
     ]
 
-    @Tool.installer("Automake")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -377,7 +377,7 @@ class PkgConfig(Tool):
         ),
     ]
 
-    @Tool.installer("PkgConfig")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)

--- a/example/infra/tools/misc.py
+++ b/example/infra/tools/misc.py
@@ -22,7 +22,7 @@ class Python(Tool):
         ),
     ]
 
-    @Tool.installer("Python")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -61,11 +61,11 @@ class PythonSite(Tool):
         ),
     ]
 
-    @Tool.action("PythonSite")
+    @Tool.action()
     def run(self, ctx: Context, *args: list[str]) -> Invocation:
         return Invocation(tool=self, execute="python3", args=args)
 
-    @Tool.installer("PythonSite")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         return Invocation(
             tool=self,
@@ -94,11 +94,11 @@ class Make(Tool):
         ),
     ]
 
-    @Tool.action("Make", default=True)
+    @Tool.action(default=True)
     def run(self, ctx: Context, *args: list[str]) -> Invocation:
         return Invocation(tool=self, execute="make", args=args)
 
-    @Tool.installer("Make")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)

--- a/example/infra/tools/objstore.py
+++ b/example/infra/tools/objstore.py
@@ -82,7 +82,7 @@ class ObjStore(Tool, metaclass=Singleton):
         with target.open("wb") as fh:
             self.store.download_fileobj(self.bucket, path, fh)
 
-    @Tool.action("ObjStore")
+    @Tool.action()
     def authenticate(self, ctx: Context, *args: list[str]) -> Invocation:
         if len(args) == 4:
             ctx.state.objstore.endpoint = args[0]
@@ -97,7 +97,7 @@ class ObjStore(Tool, metaclass=Singleton):
         ObjStore().setup(ctx)
         return None
 
-    @Tool.action("ObjStore")
+    @Tool.action()
     def lookup(self, ctx: Context, path: str) -> Invocation:
         ObjStore().setup(ctx)
         if lkp := ObjStore().get_info(path):

--- a/example/infra/tools/simulators.py
+++ b/example/infra/tools/simulators.py
@@ -25,7 +25,7 @@ class IVerilog(Tool):
         ),
     ]
 
-    @Tool.installer("IVerilog")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum.replace(".", "_")
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)
@@ -71,11 +71,11 @@ class Verilator(Tool):
         ),
     ]
 
-    @Tool.action("Verilator")
+    @Tool.action()
     def run(self, ctx: Context, *args: list[str]) -> Invocation:
         return Invocation(version=self, execute="verilator", args=args)
 
-    @Tool.installer("Verilator")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)

--- a/example/infra/tools/wave_viewers.py
+++ b/example/infra/tools/wave_viewers.py
@@ -23,7 +23,7 @@ class GTKWave(Tool):
         ),
     ]
 
-    @Tool.action("GTKWave", default=True)
+    @Tool.action(default=True)
     def view(self, ctx: Context, wavefile: str, *args: list[str]) -> Invocation:
         path = Path(wavefile).absolute()
         return Invocation(
@@ -34,7 +34,7 @@ class GTKWave(Tool):
             binds=[path.parent],
         )
 
-    @Tool.action("GTKWave")
+    @Tool.action()
     def gtk_version(self, ctx: Context, *args: list[str]) -> Invocation:
         return Invocation(
             tool=self,
@@ -43,7 +43,7 @@ class GTKWave(Tool):
             display=True,
         )
 
-    @Tool.installer("GTKWave")
+    @Tool.installer()
     def install(self, ctx: Context, *args: list[str]) -> Invocation:
         vernum = self.vernum
         tool_dir = Path("/tools") / self.location.relative_to(Tool.HOST_ROOT)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -375,7 +375,7 @@ class TestTools:
                 )
             ]
 
-            @Tool.action("Widget")
+            @Tool.action()
             def do_something(self, ctx: Context, an_arg: str, *args: list[str]) -> Invocation:
                 return Invocation(
                     tool=self,
@@ -385,7 +385,7 @@ class TestTools:
                     binds=[Path("/a/b/c")],
                 )
 
-            @Tool.action("Widget", default=True)
+            @Tool.action(default=True)
             def other_thing(self, ctx: Context, *args: list[str]) -> Invocation:
                 return Invocation(self, execute=Tool.CNTR_ROOT / "bin" / "thing")
 
@@ -421,7 +421,7 @@ class TestTools:
 
             class Widget(Tool):
                 vendor = "company"
-                version: ClassVar[list[Version]] = [
+                versions: ClassVar[list[Version]] = [
                     Version(
                         location=tool_loc,
                         version="1.1",
@@ -430,12 +430,12 @@ class TestTools:
                     )
                 ]
 
-                @Tool.action("Widget")
+                @Tool.action()
                 def default(self, ctx: Context, *args: list[str]) -> Invocation:
                     return Invocation(self, Tool.CNTR_ROOT / "bin" / "blah")
 
         assert str(exc.value) == (
-            "Cannot register an action called 'default' to tool 'Widget' as it "
+            "Cannot register an action called 'default' to tool 'widget' as it "
             "is a reserved name"
         )
 
@@ -479,7 +479,7 @@ class TestTools:
                 )
             ]
 
-            @Tool.action("Widget")
+            @Tool.action()
             def blah(self, ctx: Context, *args: list[str]) -> Invocation:
                 return Invocation(self, Tool.CNTR_ROOT / "bin" / "blah")
 


### PR DESCRIPTION
We don't need to specify the tool name in the action decorator if we tag the methods and process on subclass init