### PR TITLE
Edk/improve arg binding

### DIFF
--- a/blockwork/activities/tools.py
+++ b/blockwork/activities/tools.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import sys
+from collections.abc import Sequence
 
 import click
 from rich.console import Console
@@ -75,7 +76,7 @@ def tool(
     version: str | None,
     tool_action: str,
     tool_mode: str,
-    runargs: list[str],
+    runargs: Sequence[str],
 ) -> None:
     """
     Run an action defined by a specific tool. The tool and action is selected by
@@ -96,11 +97,10 @@ def tool(
         raise Exception(f"No action known for '{action}' on tool {tool}") from None
     # Run the action and forward the exit code
     container = Foundation(ctx, hostname=f"{ctx.config.project}_{tool}_{action}")
+    runargs = container.bind_and_map_args(ctx, runargs)
     invocation = act_def(ctx, *runargs)
     # Actions may sometimes return null invocations if they have no work to do
     if invocation is None:
         return
-    # Remap to host
-    invocation = invocation.where(host=True)
     # Launch the invocation
     sys.exit(container.invoke(ctx, invocation, readonly=(ToolMode(tool_mode) == ToolMode.READONLY)))

--- a/blockwork/foundation.py
+++ b/blockwork/foundation.py
@@ -114,9 +114,10 @@ class Foundation(Container):
 
         # Add the tool into the container (also adds dependencies)
         self.add_tool(invocation.tool, readonly=readonly)
+        # Convert remaining paths
+        args = [a.as_posix() if isinstance(a, Path) else a for a in invocation.args]
 
-        # Bind files and folders to host and remap path args
-        args = self.bind_and_map_args(context, args=invocation.args, host_okay=invocation.host)
+        # Bind files and directories
         self.bind_many(context, binds=invocation.binds)
         # Resolve the binary
         command = invocation.execute

--- a/blockwork/tools/tool.py
+++ b/blockwork/tools/tool.py
@@ -492,7 +492,6 @@ class Invocation:
     :param workdir:     Working directory within the container
     :param display:     Whether to forward X11 display (forces interactive mode)
     :param interactive: Whether to attach an interactive shell
-    :param host:        Whether to detect and bind host paths
     :param binds:       Paths to bind into the container from the host. Can be
                         provided as a single path in which case the container
                         path will be inferred, or as a tuple of a host path and
@@ -511,7 +510,6 @@ class Invocation:
         interactive: bool = False,
         stdout: TextIO | None = None,
         stderr: TextIO | None = None,
-        host: bool = False,
         binds: Sequence[Path | tuple[Path, Path]] | None = None,
         env: dict[str, str] | None = None,
         path: dict[str, list[Path]] | None = None,
@@ -524,7 +522,6 @@ class Invocation:
         self.interactive = interactive or display
         self.stdout = stdout
         self.stderr = stderr
-        self.host = host
         self.binds = binds or []
         self.env = env or {}
         self.path = path or {}

--- a/example/infra/tools/misc.py
+++ b/example/infra/tools/misc.py
@@ -76,10 +76,9 @@ class PythonSite(Tool):
                 "--no-cache-dir",
                 "install",
                 "-r",
-                ctx.host_root / "infra" / "tools" / "pythonsite.txt",
+                ctx.container_root / "infra" / "tools" / "pythonsite.txt",
             ],
             interactive=True,
-            host=True,
         )
 
 


### PR DESCRIPTION
Remove host invocation option and only bind and map pathlike args automatically on the command line - elsewhere tool/transform should control this.

Handle args possibly containing multiple clauses e.g. `command '--path /my/path'`
