### PR TITLE
Cache improvements, configuration, and docs

### DIFF
--- a/blockwork/__main__.py
+++ b/blockwork/__main__.py
@@ -86,13 +86,19 @@ logging.basicConfig(
 )
 @click.option(
     "--cache/--no-cache",
-    default=True,
+    default=None,
     help="Enable or disable caching",
 )
 @click.option(
-    "--cache-force",
-    is_flag=True,
-    default=False,
+    "--cache-config",
+    "--cc",
+    type=click.Path(dir_okay=False, exists=True, path_type=Path),
+    default=None,
+    help="Path to a cache config file.",
+)
+@click.option(
+    "--cache-target/--no-cache-target",
+    default=None,
     help="Force caching even for 'targetted' objects",
 )
 def blockwork(
@@ -105,8 +111,9 @@ def blockwork(
     runtime: str | None,
     arch: str | None,
     scratch: str | None,
-    cache: bool,
-    cache_force: bool,
+    cache: bool | None,
+    cache_config: Path,
+    cache_target: bool | None,
 ) -> None:
     # Setup post-mortem debug
     DebugScope.current.POSTMORTEM = pdb
@@ -125,8 +132,9 @@ def blockwork(
     ctx.obj = Context(
         root=Path(cwd).absolute() if cwd else None,
         scratch=Path(scratch).absolute() if scratch else None,
-        use_caches=cache,
-        force_cache=cache_force,
+        cache_enable=cache,
+        cache_config=cache_config,
+        cache_target=cache_target,
     )
     # Set the host architecture
     if arch:

--- a/blockwork/__main__.py
+++ b/blockwork/__main__.py
@@ -102,6 +102,11 @@ logging.basicConfig(
     help="Force caching even for 'targetted' transforms",
 )
 @click.option(
+    "--cache-trace/--no-cache-trace",
+    default=None,
+    help="Turn on cache debug tracing",
+)
+@click.option(
     "--cache-expect/--no-cache-expect",
     default=None,
     help="Raise exception if any transform not available in a cache",
@@ -119,6 +124,7 @@ def blockwork(
     cache: bool | None,
     cache_config: Path,
     cache_targets: bool | None,
+    cache_trace: bool | None,
     cache_expect: bool | None,
 ) -> None:
     # Setup post-mortem debug
@@ -141,6 +147,7 @@ def blockwork(
         cache_enable=cache,
         cache_config=cache_config,
         cache_targets=cache_targets,
+        cache_trace=cache_trace,
         cache_expect=cache_expect,
     )
     # Set the host architecture

--- a/blockwork/__main__.py
+++ b/blockwork/__main__.py
@@ -97,7 +97,7 @@ logging.basicConfig(
     help="Path to a cache config file.",
 )
 @click.option(
-    "--cache-target/--no-cache-target",
+    "--cache-targets/--no-cache-targets",
     default=None,
     help="Force caching even for 'targetted' objects",
 )
@@ -113,7 +113,7 @@ def blockwork(
     scratch: str | None,
     cache: bool | None,
     cache_config: Path,
-    cache_target: bool | None,
+    cache_targets: bool | None,
 ) -> None:
     # Setup post-mortem debug
     DebugScope.current.POSTMORTEM = pdb
@@ -134,7 +134,7 @@ def blockwork(
         scratch=Path(scratch).absolute() if scratch else None,
         cache_enable=cache,
         cache_config=cache_config,
-        cache_target=cache_target,
+        cache_targets=cache_targets,
     )
     # Set the host architecture
     if arch:

--- a/blockwork/__main__.py
+++ b/blockwork/__main__.py
@@ -99,7 +99,12 @@ logging.basicConfig(
 @click.option(
     "--cache-targets/--no-cache-targets",
     default=None,
-    help="Force caching even for 'targetted' objects",
+    help="Force caching even for 'targetted' transforms",
+)
+@click.option(
+    "--cache-expect/--no-cache-expect",
+    default=None,
+    help="Raise exception if any transform not available in a cache",
 )
 def blockwork(
     ctx,
@@ -114,6 +119,7 @@ def blockwork(
     cache: bool | None,
     cache_config: Path,
     cache_targets: bool | None,
+    cache_expect: bool | None,
 ) -> None:
     # Setup post-mortem debug
     DebugScope.current.POSTMORTEM = pdb
@@ -135,6 +141,7 @@ def blockwork(
         cache_enable=cache,
         cache_config=cache_config,
         cache_targets=cache_targets,
+        cache_expect=cache_expect,
     )
     # Set the host architecture
     if arch:

--- a/blockwork/activities/__init__.py
+++ b/blockwork/activities/__init__.py
@@ -14,6 +14,7 @@
 
 # Expose activities
 from .bootstrap import bootstrap
+from .cache import cache
 from .exec import exec
 from .info import info
 from .shell import shell
@@ -21,7 +22,7 @@ from .tools import tool, tools
 from .workflow import wf, wf_step
 
 # List all activities
-activities = (bootstrap, info, exec, shell, tool, tools, wf, wf_step)
+activities = (bootstrap, cache, info, exec, shell, tool, tools, wf, wf_step)
 
 # Lint guard
 assert activities

--- a/blockwork/activities/cache.py
+++ b/blockwork/activities/cache.py
@@ -1,0 +1,60 @@
+# Copyright 2023, Blockwork, github.com/intuity/blockwork
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pathlib import Path
+from pprint import pprint
+
+import click
+
+from ..build.caching import Cache
+from ..context import Context
+
+
+@click.group()
+def cache() -> None:
+    """
+    Cache utilities
+    """
+    pass
+
+
+@cache.command(name="read-key")
+@click.argument("key", type=click.STRING)
+@click.pass_obj
+def read_key(ctx: Context, key: str):
+    """
+    Read transform key data
+    """
+    data = Cache.fetch_transform_key_data_from_any(ctx, key)
+    if data:
+        pprint(data)
+        exit(0)
+    exit(1)
+
+
+@cache.command(name="fetch-medial")
+@click.argument("key", type=click.STRING)
+@click.option("--output", "-o", type=click.Path(writable=True, path_type=Path), required=True)
+@click.pass_obj
+def fetch_medial(ctx: Context, key: str, output: Path):
+    """
+    Fetch a single medial
+    """
+    if not key.startswith(Cache.medial_prefix):
+        key = Cache.medial_prefix + key
+    for cache in ctx.caches:
+        if cache.fetch_item(key, output):
+            exit(0)
+    exit(1)

--- a/blockwork/activities/cache.py
+++ b/blockwork/activities/cache.py
@@ -31,7 +31,7 @@ def cache() -> None:
     pass
 
 
-def get_key_data(ctx: Context, key: str) -> TransformKeyData | None:
+def get_key_data(ctx: Context, key: str, from_cache: str | None = None) -> TransformKeyData | None:
     if any(key.startswith(p) for p in ("./", "../", "/")):
         print(f"Assuming key '{key}' is a key_file")
 
@@ -43,6 +43,8 @@ def get_key_data(ctx: Context, key: str) -> TransformKeyData | None:
         key = Cache.transform_prefix + key
 
     for cache in ctx.caches:
+        if from_cache is not None and cache.cfg.name != from_cache:
+            continue
         data = cache.fetch_object(key)
         if data is not None:
             print(f"Key '{key}' found in cache: '{cache.cfg.name}'")
@@ -66,20 +68,13 @@ def format_trace(trace: list[TraceData], depth=0, max_depth=0) -> list[str]:
 @click.option(
     "--output", "-o", type=click.Path(writable=True, path_type=Path), required=False, default=None
 )
-@click.option("--trace", default=False, is_flag=True)
-@click.option(
-    "--trace-output",
-    "-t",
-    type=click.Path(writable=True, path_type=Path),
-    required=False,
-    default=None,
-)
+@click.option("--cache", "-c", type=click.STRING, required=False, default=None)
 @click.pass_obj
-def read_key(ctx: Context, key: str, output: Path | None, trace: bool, trace_output: Path | None):
+def read_key(ctx: Context, key: str, output: Path | None, cache: str):
     """
     Read transform key data
     """
-    data = get_key_data(ctx, key)
+    data = get_key_data(ctx, key, cache)
     if data is None:
         exit(1)
 
@@ -97,12 +92,13 @@ def read_key(ctx: Context, key: str, output: Path | None, trace: bool, trace_out
 @click.option(
     "--output", "-o", type=click.Path(writable=True, path_type=Path), required=False, default=None
 )
+@click.option("--cache", "-c", type=click.STRING, required=False, default=None)
 @click.pass_obj
-def trace_key(ctx: Context, key: str, depth: int, output: Path | None):
+def trace_key(ctx: Context, key: str, depth: int, output: Path | None, cache: str | None):
     """
     Read transform key data
     """
-    data = get_key_data(ctx, key)
+    data = get_key_data(ctx, key, cache)
     if data is None:
         exit(1)
 

--- a/blockwork/activities/cache.py
+++ b/blockwork/activities/cache.py
@@ -56,7 +56,7 @@ def format_trace(trace: list[TraceData], depth=0, max_depth=0) -> list[str]:
 
     for typ, ident, own_hash, rolling_hash, sub_trace in trace:
         lines.append(f"{depth} {rolling_hash}  {own_hash} {depth*'  '} {typ}[{ident}]")
-        if max_depth == 0 or depth < max_depth:
+        if max_depth < 0 or depth < max_depth:
             lines.extend(format_trace(sub_trace, depth=depth + 1, max_depth=max_depth))
     return lines
 
@@ -93,7 +93,7 @@ def read_key(ctx: Context, key: str, output: Path | None, trace: bool, trace_out
 
 @cache.command(name="trace-key")
 @click.argument("key", type=click.STRING)
-@click.option("--depth", "-d", type=click.INT, required=False, default=0)
+@click.option("--depth", "-d", type=click.INT, required=False, default=-1)
 @click.option(
     "--output", "-o", type=click.Path(writable=True, path_type=Path), required=False, default=None
 )
@@ -118,7 +118,8 @@ def trace_key(ctx: Context, key: str, depth: int, output: Path | None):
             print(line)
     else:
         with output.open("w") as f:
-            f.writelines(trace_lines)
+            for line in trace_lines:
+                f.write(line + "\n")
     exit(0)
 
 

--- a/blockwork/activities/exec.py
+++ b/blockwork/activities/exec.py
@@ -60,5 +60,5 @@ def exec(  # noqa: A001
             interactive=interactive,
             display=True,
             show_detach=False,
-        )
+        ).exit_code
     )

--- a/blockwork/activities/tools.py
+++ b/blockwork/activities/tools.py
@@ -103,4 +103,8 @@ def tool(
     if invocation is None:
         return
     # Launch the invocation
-    sys.exit(container.invoke(ctx, invocation, readonly=(ToolMode(tool_mode) == ToolMode.READONLY)))
+    sys.exit(
+        container.invoke(
+            ctx, invocation, readonly=(ToolMode(tool_mode) == ToolMode.READONLY)
+        ).exit_code
+    )

--- a/blockwork/activities/workflow.py
+++ b/blockwork/activities/workflow.py
@@ -35,8 +35,9 @@ def wf() -> None:
 
 @click.command(name="_wf_step", hidden=True)
 @click.argument("spec_path", type=click.Path(dir_okay=False, exists=True, path_type=Path))
+@click.argument("input_hash", type=click.STRING)
 @click.pass_obj
-def wf_step(ctx: Context, spec_path: Path):
+def wf_step(ctx: Context, spec_path: Path, input_hash: str):
     """
     Loads a serialised transform specification from a provided file path, then
     resolves the transform class and executes it. This should NOT be called
@@ -47,7 +48,7 @@ def wf_step(ctx: Context, spec_path: Path):
     # Reload the serialised workflow step specification
     spec: SerialTransform = json.loads(spec_path.read_text(encoding="utf-8"))
     # Run the relevant transform
-    tf = Transform.deserialize(spec)
+    tf = Transform.deserialize(spec, input_hash)
     result = tf.run(ctx)
 
     # duration = stop - start

--- a/blockwork/activities/workflow.py
+++ b/blockwork/activities/workflow.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import click
 
-from ..build.caching import Cache
+from ..build.caching import BWFrozenHash, Cache
 from ..context import Context
 from ..transforms.transform import SerialTransform, Transform
 
@@ -48,7 +48,7 @@ def wf_step(ctx: Context, spec_path: Path, input_hash: str):
     # Reload the serialised workflow step specification
     spec: SerialTransform = json.loads(spec_path.read_text(encoding="utf-8"))
     # Run the relevant transform
-    tf = Transform.deserialize(spec, input_hash)
+    tf = Transform.deserialize(spec, BWFrozenHash(spec["name"], bytes.fromhex(input_hash)))
     result = tf.run(ctx)
 
     # duration = stop - start

--- a/blockwork/activities/workflow.py
+++ b/blockwork/activities/workflow.py
@@ -63,7 +63,6 @@ def wf_step(ctx: Context, spec_path: Path, input_hash: str, target: bool):
         logging.info("Running transform: %s", transform)
         result = transform.run(ctx)
 
-        # duration = stop - start
         # Whether a cache is in place
         if is_caching and Cache.store_transform_to_any(ctx, transform, result.run_time):
             logging.info("Stored transform to cache: %s", transform)

--- a/blockwork/activities/workflow.py
+++ b/blockwork/activities/workflow.py
@@ -58,7 +58,7 @@ def wf_step(ctx: Context, spec_path: Path, input_hash: str, target: bool):
         and (ctx.cache_targets or not target)
         and Cache.fetch_transform_from_any(ctx, transform)
     ):
-        logging.info("Late-fetched transform to cache: %s", transform)
+        logging.info("Fetched transform from cache: %s (late)", transform)
     else:
         logging.info("Running transform: %s", transform)
         result = transform.run(ctx)

--- a/blockwork/bootstrap/tools.py
+++ b/blockwork/bootstrap/tools.py
@@ -83,7 +83,7 @@ def install_tools(context: Context, last_run: datetime) -> bool:
                 container = Foundation(
                     context, hostname=f"{context.config.project}_install_{tool.id}"
                 )
-                exit_code = container.invoke(context, act_def(context), readonly=False)
+                exit_code = container.invoke(context, act_def(context), readonly=False).exit_code
                 if exit_code != 0:
                     raise ToolError(f"Installation of {tool_id} failed")
             else:

--- a/blockwork/build/caching.py
+++ b/blockwork/build/caching.py
@@ -528,14 +528,16 @@ class Cache(ABC):
             return
 
         if (new["cls_name"], new["mod_name"]) != (old["cls_name"], old["mod_name"]):
-            raise RuntimeError("Non-deterministic transform detected!\n"
+            # Vanishingly unlikely hash collision
+            raise RuntimeError("Transform hash collision detected!\n"
                                "Transform name mismatch.\n"
                                f"Old Name: {new['mod_name']}.{new['cls_name']}\n"
                                f"New Name: {old['mod_name']}.{old['cls_name']}")
 
         if (new["mname_to_key"] != old["mname_to_key"]):
             if (keys := sorted(new["mname_to_key"].keys())) != (old_keys := sorted(old["mname_to_key"].keys())):
-                raise RuntimeError("Non-deterministic transform detected!\n"
+                # Vanishingly unlikely hash collision
+                raise RuntimeError("Transform hash collision detected!\n"
                                    "Output key mismatch.\n"
                                   f"Old keys: {old_keys}\n"
                                   f"New keys: {keys}")
@@ -556,7 +558,7 @@ class Cache(ABC):
                     new_error_path = error_dir / new_hash
                     new_error_path.symlink_to(new_path,
                                                       target_is_directory=new_path.is_dir())
-
+                    # Hash collision as a result of non-deterministic transform
                     raise RuntimeError("Non-deterministic transform detected!\n"
                                        f"New output for key `{key}` does not match existing"
                                        " output for same hash.\n"
@@ -565,8 +567,11 @@ class Cache(ABC):
 
         # I can't see how we'd get to these cases... but just in case
         if new["byte_size"] != old['byte_size']:
+            # This could happen if the original was created on a different platform
             raise RuntimeError("Non-deterministic transform detected!\n"
-                               "Size on disk different, but all outputs the same!?")
+                               "Size on disk different, but all outputs the same."
+                               f"Transform: {new['mod_name']}.{new['cls_name']}"
+                               "Perhaps original object created on a different platform?")
         raise RuntimeError("Non-deterministic transform detected!\n"
                            "Unexpected condition.")
 

--- a/blockwork/build/caching.py
+++ b/blockwork/build/caching.py
@@ -535,24 +535,24 @@ class Cache(ABC):
                                f"New Name: {old['mod_name']}.{old['cls_name']}")
 
         if (new["mname_to_key"] != old["mname_to_key"]):
-            if (keys := sorted(new["mname_to_key"].keys())) != (old_keys := sorted(old["mname_to_key"].keys())):
+            if (mkeys := sorted(new["mname_to_key"].keys())) != (old_mkeys := sorted(old["mname_to_key"].keys())):
                 # Vanishingly unlikely hash collision
                 raise RuntimeError("Transform hash collision detected!\n"
                                    "Output key mismatch.\n"
-                                  f"Old keys: {old_keys}\n"
-                                  f"New keys: {keys}")
+                                  f"Old keys: {old_mkeys}\n"
+                                  f"New keys: {mkeys}")
 
-            for key in keys:
-                new_hash = new["mname_to_key"][key]
-                old_hash = old["mname_to_key"][key]
+            for mkey in mkeys:
+                new_hash = new["mname_to_key"][mkey]
+                old_hash = old["mname_to_key"][mkey]
                 if new_hash != old_hash:
-                    error_dir = self.error_root / (new["mod_name"] + "." + new["cls_name"]) / key
+                    error_dir = self.error_root / (new["mod_name"] + "." + new["cls_name"]) / mkey / key
                     shutil.rmtree(error_dir, ignore_errors=True)
                     error_dir.mkdir(exist_ok=True, parents=True)
                     old_error_path = error_dir / old_hash
                     if not self.fetch_item(old_hash, old_error_path):
                         # Nothing to debug, just drop it.
-                        self.drop_object(key)
+                        self.drop_object(mkey)
                         continue
                     new_path = mkey_to_path[new_hash]
                     new_error_path = error_dir / new_hash
@@ -560,7 +560,7 @@ class Cache(ABC):
                                                       target_is_directory=new_path.is_dir())
                     # Hash collision as a result of non-deterministic transform
                     raise RuntimeError("Non-deterministic transform detected!\n"
-                                       f"New output for key `{key}` does not match existing"
+                                       f"New output for key `{mkey}` does not match existing"
                                        " output for same hash.\n"
                                        f"Old Output: `{old_error_path}`\n"
                                        f"New Output: `{new_error_path}`")

--- a/blockwork/build/caching.py
+++ b/blockwork/build/caching.py
@@ -108,8 +108,6 @@ class CacheDeterminismError(CacheError):
 KEY_FILE_SIZE = 250
 "The size of key files, small variance but it doesn't matter."
 
-# HashTokenType = tuple[Literal["str"], str] | tuple[Literal["path"], Path] | tuple[Literal["hash"], "BWFrozenHash"]
-
 class BWFrozenHash:
     def __init__(self, ident: str, byte_digest: bytes, trace: list[TraceData] | None = None):
         self.ident = ident

--- a/blockwork/build/caching.py
+++ b/blockwork/build/caching.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-'''
+"""
 This module contains the fundamentals required for the implementation of
 caching mechanisms. See the example project's cache for a simple working
 example.
@@ -42,18 +42,21 @@ Future improvements:
   - Pass through information such as tags, file-size, and time-to-create
     through to caches so they can make intelligent decisions on what to cache.
 
-'''
+"""
 
 from abc import ABC, abstractmethod
 import functools
 import hashlib
 import json
+import logging
+import math
 import os
 from pathlib import Path
 import sys
 import tempfile
 from types import ModuleType
-from typing import DefaultDict, Iterable, Optional, TYPE_CHECKING, TypedDict
+from typing import Any, DefaultDict, Iterable, Optional, TYPE_CHECKING, TypedDict
+
 if TYPE_CHECKING:
     from ..transforms import Transform
 from ..context import Context
@@ -62,36 +65,34 @@ from datetime import datetime, timezone
 import distutils.sysconfig
 import ast
 import site
+from ..config import CacheConfig as CacheConfig
+from humanfriendly import InvalidTimespan, parse_size, parse_timespan
 
-class MedialStoreData(TypedDict):
-    '''
-    Medial data stored as JSON in caches
-    '''
-    src: str
-    key: str
 
-class TransformStoreData(TypedDict):
-    '''
-    Transform data stored as JSON in caches
-    '''
+class TransformKeyData(TypedDict):
+    """
+    Transfrom data used to fetch transforms from caches
+    """
+
     run_time: float
     byte_size: int
-    medials: dict[str, MedialStoreData]
+    mname_to_key: dict[str, str]
 
-class MedialFetchData(TypedDict):
-    '''
-    Medial data used to fetch items from caches
-    '''
-    dst: str
+
+class TransformStoreData(TypedDict):
+    key_data: TransformKeyData
+    mkey_to_path: dict[str, Path]
+
 
 class TransformFetchData(TypedDict):
-    '''
-    Transfrom data used to fetch transforms from caches
-    '''
-    medials: dict[str, MedialFetchData]
+    mname_to_path: dict[str, Path]
+
+
+KEY_FILE_SIZE = 250
+"The size of key files, small variance but it doesn't matter."
+
 
 class PyHasher:
-
     def __init__(self):
         self.module_stack: list[ModuleType] = []
         self.dependency_map: DefaultDict[str, OSet[str]] = DefaultDict(OSet)
@@ -101,10 +102,10 @@ class PyHasher:
         self.visitor.visit_ImportFrom = self.visit_ImportFrom
 
         # Get a basic hash of the site
-        site_str =''
+        site_str = ""
         for sitepackages in site.getsitepackages():
-            site_str += ''.join(sorted(os.listdir(sitepackages)))
-        self.site_hash = hashlib.md5(site_str.encode('utf8')).hexdigest()
+            site_str += "".join(sorted(os.listdir(sitepackages)))
+        self.site_hash = hashlib.md5(site_str.encode("utf8")).hexdigest()
 
     @property
     def current_package(self):
@@ -131,7 +132,7 @@ class PyHasher:
 
         # Get context based on level (number of '.')
         level = (node.level - 1) if self.is_package(self.current_module) else node.level
-        context, *_rest = self.current_package.rsplit('.', level)
+        context, *_rest = self.current_package.rsplit(".", level)
 
         if node.module is not None:
             # `from .a import b`
@@ -147,7 +148,7 @@ class PyHasher:
         if package in self.dependency_map:
             # Don't re-process
             return
-        if (module:=sys.modules.get(package, None)) is None:
+        if (module := sys.modules.get(package, None)) is None:
             # Package may not be in sys modules if it's imported conditionally
             # or within a function etc...
             return
@@ -155,16 +156,15 @@ class PyHasher:
 
     def map_module(self, module: ModuleType):
         # Skip built-ins
-        if (module.__spec__ is None or
-            module.__spec__.origin in ["built-in", "frozen"]
-        ):
+        if module.__spec__ is None or module.__spec__.origin in ["built-in", "frozen"]:
             return
 
         # Skip standard library, pip modules, and compiled
-        if (module.__file__ is None or
-            module.__file__.startswith(distutils.sysconfig.BASE_PREFIX) or
-            module.__file__.startswith(distutils.sysconfig.PREFIX) or
-            not module.__file__.endswith('.py')
+        if (
+            module.__file__ is None
+            or module.__file__.startswith(distutils.sysconfig.BASE_PREFIX)
+            or module.__file__.startswith(distutils.sysconfig.PREFIX)
+            or not module.__file__.endswith(".py")
         ):
             return
 
@@ -176,141 +176,263 @@ class PyHasher:
         self.module_stack.append(module)
 
         # Read the file, parse it, examine imports, and record the hash
-        with open(module.__file__, 'r') as f:
+        with open(module.__file__, "r") as f:
             module_ast = ast.parse(f.read())
             self.visitor.visit(module_ast)
-            content_hash = hashlib.md5(ast.dump(module_ast).encode('utf8'))
+            content_hash = hashlib.md5(ast.dump(module_ast).encode("utf8"))
 
         # Pop the import context
         self.module_stack.pop()
 
         # Roll in the site hash
-        content_hash.update(self.site_hash.encode('utf8'))
+        content_hash.update(self.site_hash.encode("utf8"))
 
         # Roll in the dependency hashes
         for dependency in self.dependency_map[module.__name__]:
-            content_hash.update(self.hash_map[dependency].encode('utf8'))
+            content_hash.update(self.hash_map[dependency].encode("utf8"))
 
         # Record hash
         self.hash_map[module.__name__] = content_hash.hexdigest()
 
-
     def get_package_hash(self, package: str):
-        'Get the hash for a package'
+        "Get the hash for a package"
         if package not in self.hash_map:
             self.map_package(package)
         return self.hash_map[package]
 
 
 def get_byte_size(path: str | Path) -> int:
-    'Get the size of a file or directory in bytes'
+    "Get the size of a file or directory in bytes"
     if not os.path.exists(path):
         return 0
     if not os.path.isdir(path):
         return os.path.getsize(path)
     size = os.path.getsize(path)
     for dirpath, dirnames, filenames in os.walk(path):
-        for name in (dirnames + filenames):
+        for name in dirnames + filenames:
             filepath = os.path.join(dirpath, name)
             if not os.path.islink(filepath):
                 size += os.path.getsize(filepath)
     return size
+
+
+def get_byte_rate(byte_size: int, second_time: float):
+    "Calculate bytes/second, avoiding infinity with a small delta"
+    if second_time == 0:
+        second_time = 1e-9
+    return byte_size / second_time
+
 
 class Cache(ABC):
     pyhasher = PyHasher()
     medial_prefix = "md:"
     transform_prefix = "tx:"
 
+    def __init__(self, ctx: Context, cfg: CacheConfig):
+        self.ctx = ctx
+        self.cfg = cfg
+
+    @staticmethod
+    def parse_threshold(condition: str | bool) -> float:
+        """
+        Parse a cache threshold condition into seconds/byte (s/B).
+
+        Conditions can either be expressed as booleans:
+            `True`: Always
+            `False`: Never
+        or as human friendly seconds/byte expressions:
+            `1B/s`: > 1 second to create each byte.
+            `1GB/h`: > 1 hour to create each Gigabyte.
+            `5MB/4m` > 4 minutes to create each 5 Megabytes.
+        """
+        if condition is True:
+            return math.inf
+        if condition is False:
+            return 0
+
+        parts = condition.split("/")
+        if len(parts) != 2:
+            raise ValueError(
+                "Cache condition must either be expressed as a boolean or as a fraction e.g. `3MB/s`"
+            )
+        dividend, divisor = parts
+        byte_size = parse_size(dividend)
+        try:
+            seconds = parse_timespan(divisor)
+        except InvalidTimespan:
+            # Allow e.g. 5GB/1s or just 1GB/s
+            seconds = parse_timespan("1" + divisor)
+        return get_byte_rate(second_time=seconds, byte_size=byte_size)
+
+    @functools.cached_property
+    def fetch_threshold(self) -> float:
+        """
+        The threshold in terms of seconds-to-create per byte-size (s/B) at
+        which items will be fetched from this cache.
+        """
+        return Cache.parse_threshold(self.cfg.fetch_condition)
+
+    @functools.cached_property
+    def store_threshold(self) -> float:
+        """
+        The threshold in terms of seconds-to-create per byte-size (s/B) at
+        which items will be stored into this cache.
+        """
+        return Cache.parse_threshold(self.cfg.store_condition)
+
     @staticmethod
     def enabled(ctx: Context):
-        '''
+        """
         True if any cache is configured
-        '''
+        """
         return len(ctx.caches) > 0
 
     @staticmethod
     def prune_all(ctx: Context):
-        '''
+        """
         Prune all configured caches
-        '''
+        """
         for cache in ctx.caches:
             cache.prune()
 
     @functools.cache
     @staticmethod
     def hash_content(path: Path) -> str:
-        '''
+        """
         Hash the content of a file or directory. This needs to be consistent
         across caching schemes so consistency checks can be performed.
-        '''
+        """
         if not path.exists():
             assert path.is_symlink(), f"Tried to hash a path that does not exist `{path}`"
             # Symlinks might point to a path that doesn't exist and that's ok
-            content_hash = hashlib.md5(f'<symlink to {path.resolve()}>'.encode('utf8'))
+            content_hash = hashlib.md5(f"<symlink to {path.resolve()}>".encode("utf8"))
         elif path.is_dir():
-            content_hash = hashlib.md5('<dir>'.encode('utf8'))
+            content_hash = hashlib.md5("<dir>".encode("utf8"))
             for item in sorted(os.listdir(path)):
-                content_hash.update((item + Cache.hash_content(path / item)).encode('utf8'))
+                content_hash.update((item + Cache.hash_content(path / item)).encode("utf8"))
         else:
-            with path.open('rb') as f:
-                content_hash = hashlib.file_digest(f, 'md5')
+            with path.open("rb") as f:
+                content_hash = hashlib.file_digest(f, "md5")
         return content_hash.hexdigest()
 
     @staticmethod
     def hash_imported_package(package: str) -> str:
-        '''
+        """
         Hash a python package **that has already been imported**. This is
         currently implemented as a hash of module paths and modify times.
 
         In the future this could be improved by calculating the import tree
         for the module, resulting in fewer unnecessary rebuilds.
-        '''
+        """
         return Cache.pyhasher.get_package_hash(package)
 
     @staticmethod
-    def fetch_transform_from_any(ctx: Context, transform: "Transform") -> bool:
-        'Fetch all the output interfaces for a transform'
-        medials: dict[str, MedialFetchData] = {}
+    def get_transform_fetch_data(transform: "Transform") -> TransformFetchData:
+        """
+        Get the information we need from a transform in order to fetch it.
+        """
+        mname_to_path: dict[str, Path] = {}
+
         for name, serial in transform._serial_interfaces.items():
             if serial.direction.is_input:
                 continue
             for medial in serial.medials:
-                medials[name] = MedialFetchData(dst=medial.val)
-        data = TransformFetchData(medials=medials)
-
-        # Pull from the first cache that has the item
-        for cache in ctx.caches:
-            if cache.fetch_transform(f"{Cache.transform_prefix}{transform._input_hash()}", data):
-                return True
-        return False
+                mname_to_path[name] = Path(medial.val)
+        return TransformFetchData(mname_to_path=mname_to_path)
 
     @staticmethod
-    def store_transform_to_any(ctx: Context, transform: "Transform", run_time: float) -> bool:
-        'Store all the output interfaces for a transform'
-        medials: dict[str, MedialStoreData] = {}
+    def get_transform_store_data(transform: "Transform", run_time: float) -> TransformStoreData:
+        """
+        Get the information we need from a transform in order to store it.
+        """
+        mname_to_key: dict[str, str] = {}
+        mkey_to_path: dict[str, Path] = {}
+
         byte_size = 0
         for name, serial in transform._serial_interfaces.items():
             if serial.direction.is_input:
                 continue
             for medial in serial.medials:
                 byte_size += get_byte_size(medial.val)
-                medials[name] = MedialStoreData(src=medial.val, key=f"{Cache.medial_prefix}{Cache.hash_content(Path(medial.val))}")
-        data = TransformStoreData(run_time=run_time, byte_size=byte_size, medials=medials)
+                key = Cache.medial_prefix + Cache.hash_content(Path(medial.val))
+                mname_to_key[name] = key
+                mkey_to_path[key] = Path(medial.val)
+
+        return TransformStoreData(
+            key_data=TransformKeyData(
+                run_time=run_time, byte_size=byte_size, mname_to_key=mname_to_key
+            ),
+            mkey_to_path=mkey_to_path,
+        )
+
+    @staticmethod
+    def fetch_transform_from_any(ctx: Context, transform: "Transform") -> bool:
+        "Fetch all the output interfaces for a transform from any available cache"
+        key = Cache.transform_prefix + transform._input_hash()
+
+        key_data: TransformKeyData | None = None
+        for cache in ctx.caches:
+            if (key_data := cache.fetch_object(key)) is not None:
+                break
+        else:
+            return False
+
+        fetch_data = Cache.get_transform_fetch_data(transform)
+
+        mname_to_path = fetch_data["mname_to_path"]
+        mname_to_key = key_data["mname_to_key"]
+        mkey_to_path = {mname_to_key[mname]: mname_to_path[mname] for mname in mname_to_path}
+
+        byte_rate = get_byte_rate(second_time=key_data["run_time"], byte_size=key_data["byte_size"])
+
+        for cache in ctx.caches:
+            if byte_rate > cache.fetch_threshold:
+                continue
+            if cache.fetch_transform(mkey_to_path):
+                for other_cache in ctx.caches:
+                    if other_cache is cache:
+                        continue
+                    if byte_rate > other_cache.store_threshold:
+                        continue
+                    other_cache.store_object(key, key_data)
+                    other_cache.store_transform(mkey_to_path)
+                return True
+
+        return False
+
+    @staticmethod
+    def store_transform_to_any(ctx: Context, transform: "Transform", run_time: float) -> bool:
+        "Store all the output interfaces for a transform into all available cahche"
+        key = Cache.transform_prefix + transform._input_hash()
+
+        store_data = Cache.get_transform_store_data(transform, run_time)
+
+        key_data = store_data["key_data"]
+        mkey_to_path = store_data["mkey_to_path"]
+
+        byte_rate = get_byte_rate(second_time=key_data["run_time"], byte_size=key_data["byte_size"])
 
         # Store to any caches that will take it
         stored_somewhere = False
         for cache in ctx.caches:
-            if cache.store_transform(f"{Cache.transform_prefix}{transform._input_hash()}", data):
+            if byte_rate > cache.store_threshold:
+                continue
+            cache.store_object(key, key_data)
+            if cache.store_transform(mkey_to_path):
                 stored_somewhere = True
+
         return stored_somewhere
 
     def prune(self):
-        '''
-        Prune the cache down to the limit set by the target_size property.
-        '''
+        """
+        Prune the cache down to the limit set by the configuration.
+        """
         now = datetime.now(timezone.utc).timestamp()
 
-        target_size = self.target_size
+        if self.cfg.max_size is None:
+            return
+
+        target_size = parse_size(self.cfg.max_size)
 
         total_size = 0
         present_medials = set()
@@ -325,9 +447,9 @@ class Cache(ABC):
                 present_medials.add(key)
             elif key.startswith(Cache.transform_prefix):
                 # Read the transforms data
-                if (sdata:=self.fetch_value(key, peek=True)) is None:
+                store_data: TransformKeyData | None = None
+                if (store_data := self.fetch_object(key)) is None:
                     return False
-                store_data: TransformStoreData = json.loads(sdata)
                 # Calculate a usefulness score for the transform, where a
                 # lower score means less useful and a better candidate for
                 # eviction.
@@ -335,8 +457,8 @@ class Cache(ABC):
                 #  - Took a long time to run originally
                 #  - Produces small output files
                 #  - Was accessed very recently
-                run_time = store_data['run_time']
-                byte_size = store_data['byte_size'] + len(sdata.encode('utf-8'))
+                run_time = store_data["run_time"]
+                byte_size = store_data["byte_size"] + KEY_FILE_SIZE
                 fetch_delta = now - self.get_last_fetch_utc(key)
                 transform_scores[key] = run_time / byte_size / fetch_delta
                 transform_sizes[key] = byte_size
@@ -344,8 +466,8 @@ class Cache(ABC):
 
                 # Record the expected medials as some might be missing
                 transform_medials[key] = set()
-                for medial_data in store_data['medials'].values():
-                    transform_medials[key].add(medial_data['key'])
+                for medial_key in store_data["mname_to_key"].values():
+                    transform_medials[key].add(medial_key)
             else:
                 # Unexpected data - delete it.
                 self.drop_item(key)
@@ -375,134 +497,157 @@ class Cache(ABC):
         for medial in unreferenced_medials:
             self.drop_item(medial)
 
-    def store_transform(self, key: str, data: TransformStoreData) -> bool:
-        'Store a transform to the cache'
-        stored = True
-        for medial_data in data["medials"].values():
-            if self.store_item(medial_data['key'], Path(medial_data['src'])):
+    def store_transform(self, mkey_to_path: dict[str, Path]) -> bool:
+        "Store a transform to the cache"
+        for medial_key, medial_path in mkey_to_path.items():
+            if self.store_item(medial_key, medial_path):
                 continue
-            stored = False
-
-        if not stored or not self.store_value(key, json.dumps(data)):
-            for medial_data in data["medials"].values():
-                self.drop_item(medial_data['key'])
             return False
         return True
 
-    def fetch_transform(self, key: str, data: TransformFetchData) -> bool:
-        'Fetch a transform from the cache'
-        if (sdata:=self.fetch_value(key)) is None:
-            return False
-        store_data: TransformStoreData = json.loads(sdata)
-
-        for medial_key, medial_data in store_data['medials'].items():
-            if not self.fetch_item(medial_data['key'], Path(data['medials'][medial_key]['dst'])):
+    def fetch_transform(self, mkey_to_path: dict[str, Path]):
+        "Fetch a transform from the cache"
+        for medial_key, medial_path in mkey_to_path.items():
+            if not self.fetch_item(medial_key, medial_path):
                 return False
         return True
 
     def store_value(self, key: str, value: str) -> bool:
-        '''
+        """
         Try and store a string value by key. Should return True if the value
         is successfully stored or is already present.
 
         :param key:  The unique item key.
         :param frm:  The string value to be written.
         :return:     True if the item is successfully stored.
-        '''
-        with tempfile.NamedTemporaryFile('w', delete=False) as f:
+        """
+        with tempfile.NamedTemporaryFile("w", delete=False) as f:
             f.write(value)
         result = self.store_item(key, Path(f.name))
         os.unlink(f.name)
         return result
 
     def drop_value(self, key: str) -> bool:
-        '''
+        """
         Remove a string value from the store by key. Return True if item removed
         successfully.
 
         :param key:  The unique item key.
         :return:     True if the item is successfully removed
-        '''
+        """
         return self.drop_item(key)
 
+    def fetch_value(self, key: str) -> Optional[str]:
+        """
+        Fetch a string value from the store by key. Return None if not present.
 
-    def fetch_value(self, key: str, peek: bool=False) -> Optional[str]:
-        '''
+        :param key:  The unique item key.
+        :return:     The fetched string or None if the fetch failed.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "data"
+            result = self.fetch_item(key, path)
+            return path.read_text() if result else None
+
+    def store_object(self, key: str, value: Any) -> bool:
+        # TODO!
+        """
+        Try and store a string value by key. Should return True if the value
+        is successfully stored or is already present.
+
+        :param key:  The unique item key.
+        :param frm:  The string value to be written.
+        :return:     True if the item is successfully stored.
+        """
+        return self.store_value(key, json.dumps(value))
+
+    def drop_object(self, key: str) -> bool:
+        # TODO!
+        """
+        Remove a string value from the store by key. Return True if item removed
+        successfully.
+
+        :param key:  The unique item key.
+        :return:     True if the item is successfully removed
+        """
+        return self.drop_value(key)
+
+    def fetch_object(self, key: str) -> Optional[Any]:
+        # TODO!
+        """
         Fetch a string value from the store by key. Return None if not present.
 
         :param key:  The unique item key.
         :param peek: Whether to skip the fetch time update (used internally by
                      meta-operations that shouldn't affect cache state).
         :return:     The fetched string or None if the fetch failed.
-        '''
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / 'data'
-            result = self.fetch_item(key, path, peek=peek)
-            return path.read_text() if result else None
-
-    @property
-    @abstractmethod
-    def target_size(self) -> int:
-        '''
-        Get the target cache size in bytes. Note this is the level that the
-        cache will be pruned to, not a hard-limit.
-
-        :return: The target cache size in bytes
-        '''
+        """
+        value = self.fetch_value(key)
+        if value is None:
+            return None
+        return json.loads(value)
 
     @abstractmethod
     def store_item(self, key: str, frm: Path) -> bool:
-        '''
+        """
         Try and store a file or directory by key. Should return True if the
         item is successfully stored or is already present.
 
         :param key:  The unique item key.
         :param frm:  The location of the item to be copied in.
         :return:     True if the item is successfully stored.
-        '''
+        """
         ...
 
     @abstractmethod
     def drop_item(self, key: str) -> bool:
-        '''
+        """
         Remove a file or directory from the store. Must be able to handle missing
         files and directories.
 
         :param key:  The unique item key.
         :return:     True if the item is successfully removed
-        '''
+        """
         ...
 
     @abstractmethod
-    def fetch_item(self, key: str, to: Path, peek: bool=False) -> bool:
-        '''
+    def fetch_item(self, key: str, to: Path) -> bool:
+        """
         Retrieve a file or directory from the store, copying it to the path
         provided by `to`. Should return True if the item is successfully
         retreived from the cache.
 
         :param key:  The unique item key.
         :param to:   The path where the item should be copied to.
-        :param peek: Whether to skip the fetch time update (used internally by
-                     meta-operations that shouldn't affect cache state).
         :return:     Whether the item was successfully fetched.
-        '''
-        ...
-
-    @abstractmethod
-    def get_last_fetch_utc(self, key: str) -> int | float:
-        '''
-        Get the last fetch time as a UTC timestamp.
-
-        :param key:  The unique item key.
-        :return:     The last time an item was fetched as a UTC timestamp.
-        '''
+        """
         ...
 
     @abstractmethod
     def iter_keys(self) -> Iterable[str]:
-        '''
-        Iterate over keys stored in the key cache
+        """
+        Iterate over item keys stored in the cache
 
-        :return: Iterable of keys in the cache
-        '''
+        :return: Iterable of item keys in the cache
+        """
+        ...
+
+    @abstractmethod
+    def get_last_fetch_utc(self, key: str) -> int | float:
+        """
+        Get the last fetch time as a UTC timestamp.
+
+        :param key:  The unique item key.
+        :return:     The last time an item was fetched as a UTC timestamp.
+        """
+        ...
+
+    @abstractmethod
+    def set_last_fetch_utc(self, key: str) -> int | float:
+        """
+        Update the last fetch time as a UTC timestamp.
+
+        :param key:  The unique item key.
+        :return:     The last time an item was fetched as a UTC timestamp.
+        """
         ...

--- a/blockwork/build/caching.py
+++ b/blockwork/build/caching.py
@@ -167,12 +167,6 @@ class PyHasher:
         self.visitor.visit_Import = self.visit_Import
         self.visitor.visit_ImportFrom = self.visit_ImportFrom
 
-        # Get a basic hash of the site
-        site_str = ""
-        for sitepackages in site.getsitepackages():
-            site_str += "".join(sorted(os.listdir(sitepackages)))
-        self.site_hash = BWHash("site").with_str(site_str).frozen()
-
     @property
     def current_package(self):
         return self.module_stack[-1].__name__
@@ -248,9 +242,6 @@ class PyHasher:
         self.module_stack.append(module)
 
         content_hash = BWHash(module.__file__)
-
-        # Roll in the site hash
-        content_hash.update_hash(self.site_hash)
 
         # Read the file, parse it, examine imports, and record the hash
         with open(module.__file__, "r") as f:

--- a/blockwork/build/caching.py
+++ b/blockwork/build/caching.py
@@ -550,10 +550,9 @@ class Cache(ABC):
             return path.read_text() if result else None
 
     def store_object(self, key: str, value: Any) -> bool:
-        # TODO!
         """
-        Try and store a string value by key. Should return True if the value
-        is successfully stored or is already present.
+        Try and store a JSON-able object by key. Should return True if the
+        object is successfully stored or is already present.
 
         :param key:  The unique item key.
         :param frm:  The string value to be written.
@@ -562,9 +561,8 @@ class Cache(ABC):
         return self.store_value(key, json.dumps(value))
 
     def drop_object(self, key: str) -> bool:
-        # TODO!
         """
-        Remove a string value from the store by key. Return True if item removed
+        Remove an object from the store by key. Return True if item removed
         successfully.
 
         :param key:  The unique item key.
@@ -573,13 +571,10 @@ class Cache(ABC):
         return self.drop_value(key)
 
     def fetch_object(self, key: str) -> Optional[Any]:
-        # TODO!
         """
-        Fetch a string value from the store by key. Return None if not present.
+        Fetch an object from the store by key. Return None if not present.
 
         :param key:  The unique item key.
-        :param peek: Whether to skip the fetch time update (used internally by
-                     meta-operations that shouldn't affect cache state).
         :return:     The fetched string or None if the fetch failed.
         """
         value = self.fetch_value(key)

--- a/blockwork/build/caching.py
+++ b/blockwork/build/caching.py
@@ -404,7 +404,7 @@ class Cache(ABC):
                         mhash = medial._content_hash()
                     else:
                         # Compute hash based on definition
-                        mhash = hashlib.md5((serial._input_hash() + name + str(midx)).encode()).hexdigest()
+                        mhash = hashlib.md5((transform._input_hash() + name + str(midx)).encode()).hexdigest()
                     byte_size += medial._byte_size()
                     key = Cache.medial_prefix + mhash
                     mname_to_okeys[name].append(key)

--- a/blockwork/build/caching.py
+++ b/blockwork/build/caching.py
@@ -48,7 +48,6 @@ from abc import ABC, abstractmethod
 import functools
 import hashlib
 import json
-import logging
 import math
 import os
 from pathlib import Path
@@ -594,7 +593,6 @@ class Cache(ABC):
         """
         ...
 
-    @abstractmethod
     def drop_item(self, key: str) -> bool:
         """
         Remove a file or directory from the store. Must be able to handle missing
@@ -603,7 +601,7 @@ class Cache(ABC):
         :param key:  The unique item key.
         :return:     True if the item is successfully removed
         """
-        ...
+        return False
 
     @abstractmethod
     def fetch_item(self, key: str, to: Path) -> bool:
@@ -618,16 +616,14 @@ class Cache(ABC):
         """
         ...
 
-    @abstractmethod
     def iter_keys(self) -> Iterable[str]:
         """
         Iterate over item keys stored in the cache
 
         :return: Iterable of item keys in the cache
         """
-        ...
+        yield from []
 
-    @abstractmethod
     def get_last_fetch_utc(self, key: str) -> int | float:
         """
         Get the last fetch time as a UTC timestamp.
@@ -635,14 +631,12 @@ class Cache(ABC):
         :param key:  The unique item key.
         :return:     The last time an item was fetched as a UTC timestamp.
         """
-        ...
+        return 0
 
-    @abstractmethod
-    def set_last_fetch_utc(self, key: str) -> int | float:
+    def set_last_fetch_utc(self, key: str):
         """
         Update the last fetch time as a UTC timestamp.
 
         :param key:  The unique item key.
-        :return:     The last time an item was fetched as a UTC timestamp.
         """
-        ...
+        return

--- a/blockwork/config/__init__.py
+++ b/blockwork/config/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .blockwork import Blockwork
+from .blockwork import Blockwork, BlockworkParser
+from .caching import CacheConfig, CachingConfig, CachingParser
 
-assert all((Blockwork,))
+assert all((Blockwork, BlockworkParser, CacheConfig, CachingConfig, CachingParser))

--- a/blockwork/config/blockwork.py
+++ b/blockwork/config/blockwork.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from ..common.checkeddataclasses import dataclass, field
+from ..common.yaml import DataclassConverter, SimpleParser
 
 
 @dataclass
@@ -30,8 +31,7 @@ class Blockwork:
     bootstrap: list[str] = field(default_factory=list)
     tooldefs: list[str] = field(default_factory=list)
     workflows: list[str] = field(default_factory=list)
-    caches: list[str] = field(default_factory=list)
-    "Caches in order of fetch preference (fastest should be first)"
+    default_cache_config: str | None = None
 
     @root.check
     @scratch.check
@@ -39,3 +39,6 @@ class Blockwork:
     def abs_path(_field, value):
         if not value.startswith("/"):
             raise TypeError(f"Expected absolute path, but got {value}")
+
+
+BlockworkParser = SimpleParser(Blockwork, DataclassConverter)

--- a/blockwork/config/caching.py
+++ b/blockwork/config/caching.py
@@ -25,7 +25,7 @@ class CacheConfig:
     max_size: str | None = None
     fetch_condition: bool | str = False
     store_condition: bool | str = False
-    check_only: bool = False
+    check_determinism: bool = True
 
 
 @_registry.register(DataclassConverter, tag="!Caching")

--- a/blockwork/config/caching.py
+++ b/blockwork/config/caching.py
@@ -33,6 +33,7 @@ class CacheConfig:
 class CachingConfig:
     enabled: bool = True
     targets: bool = False
+    expect: bool = False
     caches: list[CacheConfig] = field(default_factory=list)
 
 

--- a/blockwork/config/caching.py
+++ b/blockwork/config/caching.py
@@ -35,6 +35,7 @@ class CachingConfig:
     enabled: bool = True
     targets: bool = False
     expect: bool = False
+    trace: bool = False
     caches: list[CacheConfig] = field(default_factory=list)
 
 

--- a/blockwork/config/caching.py
+++ b/blockwork/config/caching.py
@@ -21,6 +21,7 @@ _registry = ConverterRegistry()
 @_registry.register(DataclassConverter, tag="!Cache")
 @dataclass
 class CacheConfig:
+    name: str
     path: str
     max_size: str | None = None
     fetch_condition: bool | str = False

--- a/blockwork/config/caching.py
+++ b/blockwork/config/caching.py
@@ -1,0 +1,39 @@
+# Copyright 2023, Blockwork, github.com/intuity/blockwork
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..common.checkeddataclasses import dataclass, field
+from ..common.yaml import ConverterRegistry, DataclassConverter, Parser
+
+_registry = ConverterRegistry()
+
+
+@_registry.register(DataclassConverter, tag="!Cache")
+@dataclass
+class CacheConfig:
+    path: str
+    max_size: str | None = None
+    fetch_condition: bool | str = False
+    store_condition: bool | str = False
+    check_only: bool = False
+
+
+@_registry.register(DataclassConverter, tag="!Caching")
+@dataclass
+class CachingConfig:
+    enabled: bool = True
+    targets: bool = False
+    caches: list[CacheConfig] = field(default_factory=list)
+
+
+CachingParser = Parser(_registry)(CachingConfig)

--- a/blockwork/containers/__init__.py
+++ b/blockwork/containers/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Expose various definitions
-from .container import Container, ContainerBindError, ContainerError
+from .container import Container, ContainerBindError, ContainerError, ContainerResult
 from .runtime import Runtime
 
 # Unused import lint guards
-assert all((Container, ContainerError, ContainerBindError, Runtime))
+assert all((Container, ContainerError, ContainerBindError, ContainerResult, Runtime))

--- a/blockwork/containers/common.py
+++ b/blockwork/containers/common.py
@@ -46,7 +46,7 @@ def get_raw_input():
         tty.setraw(stdin)
 
         # Yield a function to get a input
-        def _get_char():
+        def _get_char() -> bytes | None:
             # Wait up to one second for data
             rlist, _, _ = select.select([sys.stdin], [], [], 0.1)
             # If data available
@@ -125,9 +125,12 @@ def read_stream(socket: SocketIO, stdout: TextIO, e_done: Event) -> Thread:
 
 
 def write_stream(
-    socket: SocketIO, e_done: Event, e_sent: Event, command: list[str] | None = None
+    socket: SocketIO, e_done: Event, e_interacted: Event, command: list[str] | None = None
 ) -> Thread:
     """Wrapped thread method to capture STDIN and write into container"""
+    # Format Effector escape bytes can be ignored for detecting user
+    # interaction.
+    fe_escape_byte = bytes([0x1B])
 
     def _inner(socket, e_done, command):
         with get_raw_input() as get_char:
@@ -139,7 +142,9 @@ def write_stream(
                 while not e_done.is_set():
                     if (char := get_char()) is not None:
                         socket._sock.send(char)
-                        e_sent.set()
+                        if not char.startswith(fe_escape_byte):
+                            # Detected user interaction
+                            e_interacted.set()
             except BrokenPipeError:
                 pass
         # Set event to signal completion of stream

--- a/blockwork/containers/common.py
+++ b/blockwork/containers/common.py
@@ -124,7 +124,9 @@ def read_stream(socket: SocketIO, stdout: TextIO, e_done: Event) -> Thread:
     return thread
 
 
-def write_stream(socket: SocketIO, e_done: Event, command: list[str] | None = None) -> Thread:
+def write_stream(
+    socket: SocketIO, e_done: Event, e_sent: Event, command: list[str] | None = None
+) -> Thread:
     """Wrapped thread method to capture STDIN and write into container"""
 
     def _inner(socket, e_done, command):
@@ -137,6 +139,7 @@ def write_stream(socket: SocketIO, e_done: Event, command: list[str] | None = No
                 while not e_done.is_set():
                     if (char := get_char()) is not None:
                         socket._sock.send(char)
+                        e_sent.set()
             except BrokenPipeError:
                 pass
         # Set event to signal completion of stream

--- a/blockwork/context.py
+++ b/blockwork/context.py
@@ -29,11 +29,8 @@ if TYPE_CHECKING:
     from .build.caching import Cache
 
 from .common import scopes
-from .common.yaml import DataclassConverter, SimpleParser
-from .config import Blockwork
+from .config import Blockwork, BlockworkParser, CachingConfig, CachingParser
 from .state import State
-
-BlockworkConfig = SimpleParser(Blockwork, DataclassConverter)
 
 
 @scopes.scope
@@ -82,18 +79,20 @@ class Context:
     def __init__(
         self,
         root: Path | None = None,
-        cfg_file: str = ".bw.yaml",
+        cfg_file: Path = Path(".bw.yaml"),
         scratch: Path | None = None,
-        use_caches: bool = True,
-        force_cache: bool = False,
+        cache_config: Path | None = None,
+        cache_enable: bool | None = None,
+        cache_target: bool | None = None,
     ) -> None:
         self.__file = cfg_file
         self.__host_root = self.locate_root(root or Path.cwd())
         self.__host_arch = HostArchitecture.identify()
         self.__scratch = scratch
         self.__timestamp = datetime.now().strftime("D%Y%m%dT%H%M%S")
-        self.__use_caches = use_caches
-        self.__force_cache = force_cache
+        self.__cache_config = cache_config
+        self.__cache_enable = cache_enable
+        self.__cache_target = cache_target
 
     @property
     def host_architecture(self) -> HostArchitecture:
@@ -216,27 +215,35 @@ class Context:
             current = nxtdir
         raise Exception(f"Could not identify work area in parents of {under}")
 
-    @property
-    @functools.lru_cache  # noqa: B019
+    @functools.cached_property
     def config(self) -> Blockwork:
-        return BlockworkConfig.parse(self.config_path)
+        return BlockworkParser.parse(self.config_path)
 
-    @property
-    @functools.lru_cache  # noqa: B019
+    @functools.cached_property
+    def cache_config(self) -> CachingConfig:
+        config_path = self.__cache_config or self.config.default_cache_config
+        if config_path is None:
+            return CachingConfig()
+        return CachingParser.parse(Path(config_path))
+
+    @functools.cached_property
     def caches(self) -> list["Cache"]:
         "Import and initialise the caches from config"
-        if not self.__use_caches:
+        cache_enabled = (
+            self.cache_config.enabled if self.__cache_enable is None else self.__cache_enable
+        )
+        if not cache_enabled:
             return []
 
         if self.host_root.absolute().as_posix() not in sys.path:
             sys.path.append(self.host_root.absolute().as_posix())
 
         caches = []
-        for cache in self.config.caches:
-            module_path, class_name = cache.rsplit(".", 1)
+        for cache_config in self.cache_config.caches:
+            module_path, class_name = cache_config.path.rsplit(".", 1)
             module = importlib.import_module(module_path)
             cache_cls = getattr(module, class_name)
-            cache = cache_cls(self)
+            cache = cache_cls(self, cache_config)
             caches.append(cache)
 
         return caches
@@ -247,7 +254,7 @@ class Context:
         True if caching is forced (even targetted objects are retrieved from
         cache)
         """
-        return self.__force_cache
+        return self.__cache_target
 
     @property
     def hub_url(self):

--- a/blockwork/context.py
+++ b/blockwork/context.py
@@ -220,8 +220,15 @@ class Context:
         return BlockworkParser.parse(self.config_path)
 
     @functools.cached_property
-    def cache_config(self) -> CachingConfig:
+    def cache_config_path(self) -> Path | None:
         config_path = self.__cache_config or self.config.default_cache_config
+        if config_path is not None:
+            config_path = Path(config_path)
+        return config_path
+
+    @functools.cached_property
+    def cache_config(self) -> CachingConfig:
+        config_path = self.cache_config_path
         if config_path is None:
             return CachingConfig()
         return CachingParser.parse(Path(config_path))

--- a/blockwork/context.py
+++ b/blockwork/context.py
@@ -85,6 +85,7 @@ class Context:
         cache_enable: bool | None = None,
         cache_targets: bool | None = None,
         cache_expect: bool | None = None,
+        cache_trace: bool | None = None,
     ) -> None:
         self.__file = cfg_file
         self.__host_root = self.locate_root(root or Path.cwd())
@@ -95,6 +96,7 @@ class Context:
         self.__cache_enable = cache_enable
         self.__cache_targets = cache_targets
         self.__cache_expect = cache_expect
+        self.cache_trace = cache_trace
 
     @property
     def host_architecture(self) -> HostArchitecture:
@@ -272,6 +274,26 @@ class Context:
         is not the case.
         """
         return self.cache_config.expect if self.__cache_expect is None else self.__cache_expect
+
+    @property
+    def cache_trace(self):
+        """
+        True if cache tracing is turned on which adds extra tracing information into the
+        key files.
+
+        This is expensive.
+        """
+        from .build.caching import BWHash
+
+        return BWHash.keep_trace
+
+    @cache_trace.setter
+    def cache_trace(self, value):
+        from .build.caching import BWHash
+
+        BWHash.keep_trace = BWHash.keep_trace or (
+            self.cache_config.trace if value is None else value
+        )
 
     @property
     def hub_url(self):

--- a/blockwork/context.py
+++ b/blockwork/context.py
@@ -83,7 +83,7 @@ class Context:
         scratch: Path | None = None,
         cache_config: Path | None = None,
         cache_enable: bool | None = None,
-        cache_target: bool | None = None,
+        cache_targets: bool | None = None,
     ) -> None:
         self.__file = cfg_file
         self.__host_root = self.locate_root(root or Path.cwd())
@@ -92,7 +92,7 @@ class Context:
         self.__timestamp = datetime.now().strftime("D%Y%m%dT%H%M%S")
         self.__cache_config = cache_config
         self.__cache_enable = cache_enable
-        self.__cache_target = cache_target
+        self.__cache_targets = cache_targets
 
     @property
     def host_architecture(self) -> HostArchitecture:
@@ -256,12 +256,12 @@ class Context:
         return caches
 
     @property
-    def caching_forced(self):
+    def cache_targets(self):
         """
         True if caching is forced (even targetted objects are retrieved from
         cache)
         """
-        return self.cache_config.targets if self.__cache_target is None else self.__cache_target
+        return self.cache_config.targets if self.__cache_targets is None else self.__cache_targets
 
     @property
     def hub_url(self):

--- a/blockwork/context.py
+++ b/blockwork/context.py
@@ -261,7 +261,7 @@ class Context:
         True if caching is forced (even targetted objects are retrieved from
         cache)
         """
-        return self.__cache_target
+        return self.cache_config.targets if self.__cache_target is None else self.__cache_target
 
     @property
     def hub_url(self):

--- a/blockwork/context.py
+++ b/blockwork/context.py
@@ -84,6 +84,7 @@ class Context:
         cache_config: Path | None = None,
         cache_enable: bool | None = None,
         cache_targets: bool | None = None,
+        cache_expect: bool | None = None,
     ) -> None:
         self.__file = cfg_file
         self.__host_root = self.locate_root(root or Path.cwd())
@@ -93,6 +94,7 @@ class Context:
         self.__cache_config = cache_config
         self.__cache_enable = cache_enable
         self.__cache_targets = cache_targets
+        self.__cache_expect = cache_expect
 
     @property
     def host_architecture(self) -> HostArchitecture:
@@ -262,6 +264,14 @@ class Context:
         cache)
         """
         return self.cache_config.targets if self.__cache_targets is None else self.__cache_targets
+
+    @property
+    def cache_expect(self):
+        """
+        True if all objects are expected to be in a cache. Will throw if this
+        is not the case.
+        """
+        return self.cache_config.expect if self.__cache_expect is None else self.__cache_expect
 
     @property
     def hub_url(self):

--- a/blockwork/foundation.py
+++ b/blockwork/foundation.py
@@ -15,7 +15,7 @@
 import logging
 from pathlib import Path
 
-from .containers import Container
+from .containers import Container, ContainerResult
 from .context import Context, ContextContainerPathError
 from .tools import Invocation, Tool
 
@@ -98,7 +98,9 @@ class Foundation(Container):
                     segment = tool.get_container_path(self.context, segment).as_posix()
                 self.prepend_env_path(key, segment)
 
-    def invoke(self, context: Context, invocation: Invocation, readonly: bool = True) -> int:
+    def invoke(
+        self, context: Context, invocation: Invocation, readonly: bool = True
+    ) -> ContainerResult:
         """
         Evaluate a tool invocation by binding the required tools and setting up
         the environment as per the request.

--- a/blockwork/transforms/__init__.py
+++ b/blockwork/transforms/__init__.py
@@ -1,6 +1,6 @@
 # Expose various definitions
 from . import transforms
-from .transform import IN, OUT, EnvPolicy, IEnv, IFace, IPath, Result, Transform
+from .transform import IN, OUT, EnvPolicy, IEnv, IFace, IPath, Transform, TransformResult
 
 # Unused import lint guards
-assert all((EnvPolicy, IEnv, IFace, IN, IPath, OUT, Transform, Result, transforms))
+assert all((EnvPolicy, IEnv, IFace, IN, IPath, OUT, Transform, TransformResult, transforms))

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -1204,6 +1204,9 @@ class Transform:
     _cached_input_hash: str | None = None
     "The (cached) hash of this transforms inputs"
 
+    _cached_import_hash: str | None = None
+    "The (cached) hash of this transforms imports"
+
     api: ConfigApi
 
     def __init_subclass__(cls, *args, **kwargs):
@@ -1251,7 +1254,11 @@ class Transform:
         }
 
     def _import_hash(self) -> str:
-        return Cache.hash_imported_package(self.__class__.__module__)
+        if self._cached_import_hash is not None:
+            return self._cached_import_hash
+        digest = Cache.hash_imported_package(self.__class__.__module__)
+        object.__setattr__(self, "_cached_import_hash", digest)
+        return digest
 
     def _input_hash(self) -> str:
         """

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -1308,7 +1308,7 @@ class Transform:
         return digest
 
     @staticmethod
-    def deserialize(spec: SerialTransform) -> "Transform":
+    def deserialize(spec: SerialTransform, input_hash: str | None = None) -> "Transform":
         # Get transform module
         mod = importlib.import_module(spec["mod"])
         # Get class from module (using reduce to navigate module namespacing)
@@ -1328,7 +1328,7 @@ class Transform:
                 direction=ifield.direction,
                 deterministic=ifield.deterministic,
             )
-
+        object.__setattr__(tf, "_cached_input_hash", input_hash)
         return tf
 
     def run(self, ctx: "Context") -> TransformResult:

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -924,7 +924,9 @@ class ITool(FieldProtocol[Tool]):
             # Set the resolved value on the transform
             object.__setattr__(target, field.name, field_value)
         # Serialise the tool version
-        return SerialInterface.from_interface(field_value.vernum, self.direction)
+        return SerialInterface.from_interface(
+            field_value.vernum, direction=self.direction, deterministic=self.deterministic
+        )
 
     def bind(
         self,

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -1306,7 +1306,7 @@ class Transform:
         return frozen
 
     @staticmethod
-    def deserialize(spec: SerialTransform, input_hash: str | None = None) -> "Transform":
+    def deserialize(spec: SerialTransform, input_hash: BWFrozenHash | None = None) -> "Transform":
         # Get transform module
         mod = importlib.import_module(spec["mod"])
         # Get class from module (using reduce to navigate module namespacing)

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -20,7 +20,7 @@ import time
 from collections.abc import Callable, Generator, Sequence
 from dataclasses import Field, dataclass, field, fields
 from enum import Enum, auto
-from functools import reduce
+from functools import cached_property, reduce
 from pathlib import Path
 from types import EllipsisType, GenericAlias, NoneType
 from typing import (
@@ -1218,11 +1218,19 @@ class Transform:
                 ifield = tf_field.default
                 self._serial_interfaces[tf_field.name] = ifield.resolve(self, api, tf_field)
 
+    @cached_property
+    def _mod_name(self) -> str:
+        return type(self).__module__
+
+    @cached_property
+    def _cls_name(self) -> str:
+        return type(self).__qualname__
+
     def serialize(self) -> SerialTransform:
         return {
             "typ": "Transform",
-            "mod": type(self).__module__,
-            "name": type(self).__qualname__,
+            "mod": self._mod_name,
+            "name": self._cls_name,
             "ifaces": {k: v.value for k, v in self._serial_interfaces.items()},
         }
 

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -910,6 +910,7 @@ class ITool(FieldProtocol[Tool]):
         self.init = init
         self.version = version
         self.direction = Direction.INPUT
+        self.deterministic = True
 
     def resolve(
         self, target: "Transform | IFace", api: ConfigApi, field: Field[Tool]
@@ -1321,7 +1322,9 @@ class Transform:
                 )
             ifield = tf_field.default
             tf._serial_interfaces[tf_field.name] = SerialInterface(
-                spec["ifaces"][tf_field.name], direction=ifield.direction
+                spec["ifaces"][tf_field.name],
+                direction=ifield.direction,
+                deterministic=ifield.deterministic,
             )
 
         return tf

--- a/blockwork/transforms/transform.py
+++ b/blockwork/transforms/transform.py
@@ -1291,8 +1291,8 @@ class Transform:
         """
         if self._cached_input_hash is not None:
             return self._cached_input_hash
-
-        bw_hash = BWHash(self._cls_name)
+        full_name = f"{self._mod_name}.{self._cls_name}"
+        bw_hash = BWHash(full_name).with_str(full_name)
         bw_hash.update_hash(self._import_hash())
         for name, serial in self._serial_interfaces.items():
             if serial.direction.is_output:

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -268,10 +268,14 @@ class Workflow:
                     status.run.add(transform)
 
                     if is_caching:
-                        if result.interacted or transform in interacted:
+                        if result.interacted:
                             interacted.add(transform)
                             interacted |= scheduler._dependent_map[transform]
                             logging.warning("Not caching due to user interaction: %s", transform)
+                        elif transform in interacted:
+                            logging.warning(
+                                "Not caching due to (dependency) user interaction: %s", transform
+                            )
                         elif Cache.store_transform_to_any(ctx, transform, result.run_time):
                             status.stored.add(transform)
                             logging.info("Stored transform to cache: %s", transform)

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -362,8 +362,6 @@ class Workflow:
                         args += ["--cache-config", ctx.cache_config_path.as_posix()]
                     if ctx.cache_expect is not None:
                         args += ["--cache-expect" if ctx.cache_expect else "--no-cache-expect"]
-                    if ctx.cache_targets is not None:
-                        args += ["--cache-targets" if ctx.cache_targets else "--no-cache-targets"]
                     args += ["_wf_step", spec_file.as_posix(), transform._input_hash().hex_digest()]
                     if DebugScope.current.VERBOSE:
                         args.insert(0, "--verbose")

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -360,9 +360,9 @@ class Workflow:
                     if ctx.cache_config_path is not None:
                         args += ["--cache-config", ctx.cache_config_path.as_posix()]
                     if ctx.cache_expect is not None:
-                        args += ["--cache-expect"] if ctx.cache_expect else "--no-cache-expect"
+                        args += ["--cache-expect" if ctx.cache_expect else "--no-cache-expect"]
                     if ctx.cache_targets is not None:
-                        args += ["--cache-targets"] if ctx.cache_targets else "--no-cache-targets"
+                        args += ["--cache-targets" if ctx.cache_targets else "--no-cache-targets"]
                     args += [
                         "_wf_step",
                         spec_file.as_posix(),

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -334,6 +334,7 @@ class Workflow:
                 elif transform in status.skipped:
                     logging.info(f"Skipped transform (due to cached dependents): {transform}")
                 else:
+                    logging.info(f"Scheduled transform: {transform}")
                     dependencies = transform_dependencies[transform]
                     dependents = transform_dependents[transform]
                     group = groups[dependencies, dependents]
@@ -363,10 +364,7 @@ class Workflow:
                         args += ["--cache-expect" if ctx.cache_expect else "--no-cache-expect"]
                     if ctx.cache_targets is not None:
                         args += ["--cache-targets" if ctx.cache_targets else "--no-cache-targets"]
-                    args += [
-                        "_wf_step",
-                        spec_file.as_posix(),
-                    ]
+                    args += ["_wf_step", spec_file.as_posix(), transform._input_hash()]
                     if DebugScope.current.VERBOSE:
                         args.insert(0, "--verbose")
                     # Give jobs a descriptive name where possible

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -414,26 +414,27 @@ class Workflow:
                 )
             )
 
-            # For any failed IDs, resolve them to their log files
-            for job_id in summary.failed_ids:
-                ptr = root_group
-                # Resolve the job
-                for idx, part in enumerate(job_id[1:]):
-                    for sub in ptr.jobs:
-                        if sub.ident == part:
-                            ptr = sub
-                            break
-                    else:
-                        raise Exception(
-                            f"Failed to resolve '{part}' within {'.'.join(job_id[:idx])}"
-                        )
-                # Grab the spec JSON
-                *_, spec_json = ptr.args
-                with Path(spec_json).open("r", encoding="utf-8") as fh:
-                    spec_data = json.load(fh)
-                # Grab the tracking directory
-                job_trk_dirx = track_dirx / "/".join(job_id[1:])
-                logging.error(f"{spec_data['name']} failed: {job_trk_dirx / 'messages.log'}")
+            if DebugScope.current.VERBOSE:
+                # For any failed IDs, resolve them to their log files
+                for job_id in summary.failed_ids:
+                    ptr = root_group
+                    # Resolve the job
+                    for idx, part in enumerate(job_id[1:]):
+                        for sub in ptr.jobs:
+                            if sub.ident == part:
+                                ptr = sub
+                                break
+                        else:
+                            raise Exception(
+                                f"Failed to resolve '{part}' within {'.'.join(job_id[:idx])}"
+                            )
+                    # Grab the spec JSON
+                    *_, spec_json = ptr.args
+                    with Path(spec_json).open("r", encoding="utf-8") as fh:
+                        spec_data = json.load(fh)
+                    # Grab the tracking directory
+                    job_trk_dirx = track_dirx / "/".join(job_id[1:])
+                    logging.error(f"{spec_data['name']} failed: {job_trk_dirx / 'messages.log'}")
 
             # Check for failure
             if summary.failed:

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -484,7 +484,7 @@ class Workflow:
             while cache_scheduler.incomplete:
                 for transform in cache_scheduler.schedulable:
                     cache_scheduler.schedule(transform)
-                    if ctx.caching_forced or transform not in targets:
+                    if ctx.cache_targets or transform not in targets:
                         if not (
                             dependent_map[transform] - status.skipped
                             or dependent_map[transform] - status.fetched

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -364,7 +364,7 @@ class Workflow:
                         args += ["--cache-expect" if ctx.cache_expect else "--no-cache-expect"]
                     if ctx.cache_targets is not None:
                         args += ["--cache-targets" if ctx.cache_targets else "--no-cache-targets"]
-                    args += ["_wf_step", spec_file.as_posix(), transform._input_hash()]
+                    args += ["_wf_step", spec_file.as_posix(), transform._input_hash().hex_digest()]
                     if DebugScope.current.VERBOSE:
                         args.insert(0, "--verbose")
                     # Give jobs a descriptive name where possible

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -274,7 +274,7 @@ class Workflow:
                         and (ctx.cache_targets or transform not in targets)
                         and Cache.fetch_transform_from_any(ctx, transform)
                     ):
-                        logging.info("Late-fetched transform to cache: %s", transform)
+                        logging.info("Fetched transform from cache: %s (late)", transform)
                         status.fetched.add(transform)
                     else:
                         logging.info("Running transform: %s", transform)

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -359,6 +359,10 @@ class Workflow:
                     ]
                     if ctx.cache_config_path is not None:
                         args += ["--cache-config", ctx.cache_config_path.as_posix()]
+                    if ctx.cache_expect is not None:
+                        args += ["--cache-expect"] if ctx.cache_expect else "--no-cache-expect"
+                    if ctx.cache_targets is not None:
+                        args += ["--cache-targets"] if ctx.cache_targets else "--no-cache-targets"
                     args += [
                         "_wf_step",
                         spec_file.as_posix(),

--- a/blockwork/workflows/workflow.py
+++ b/blockwork/workflows/workflow.py
@@ -344,6 +344,10 @@ class Workflow:
                     args = [
                         "--scratch",
                         ctx.host_scratch.as_posix(),
+                    ]
+                    if ctx.cache_config_path is not None:
+                        args += ["--cache-config", ctx.cache_config_path.as_posix()]
+                    args += [
                         "_wf_step",
                         spec_file.as_posix(),
                     ]

--- a/docs/config/bw_yaml.md
+++ b/docs/config/bw_yaml.md
@@ -22,17 +22,18 @@ tooldefs    :
 
 The fields of the `!Blockwork` tag are:
 
-| Field        | Required         | Default                | Description                                                             |
-|--------------|:----------------:|------------------------|-------------------------------------------------------------------------|
-| project      | :material-check: |                        | Sets the project's name                                                 |
-| root         |                  | `/project`             | Location to map the project's root directory inside the container       |
-| scratch      |                  | `/scratch`             | Location to map the scratch area inside the container                   |
-| tools        |                  | `/tools`               | Location to map the tools inside the container                          |
-| host_scratch |                  | `../{project}.scratch` | Directory to store build objects and other artefacts                    |
-| host_state   |                  | `../{project}.state`   | Directory to store Blockwork's state information for the project        |
-| host_tools   |                  | `../{project}.tools`   | Directory containing tool installations on the host                     |
-| bootstrap    |                  |                        | Python paths containing [Bootstrap](../syntax/bootstrap.md) definitions |
-| tooldefs     |                  |                        | Python paths containing [Tool](../syntax/tools.md) definitions          |
+| Field                | Required         | Default                | Description                                                                |
+|----------------------|:----------------:|------------------------|----------------------------------------------------------------------------|
+| project              | :material-check: |                        | Sets the project's name                                                    |
+| root                 |                  | `/project`             | Location to map the project's root directory inside the container          |
+| scratch              |                  | `/scratch`             | Location to map the scratch area inside the container                      |
+| tools                |                  | `/tools`               | Location to map the tools inside the container                             |
+| host_scratch         |                  | `../{project}.scratch` | Directory to store build objects and other artefacts                       |
+| host_state           |                  | `../{project}.state`   | Directory to store Blockwork's state information for the project           |
+| host_tools           |                  | `../{project}.tools`   | Directory containing tool installations on the host                        |
+| default_cache_config |                  |                        | Path to the default cache configuration, see [Caching](../tech/caching.md) |
+| bootstrap            |                  |                        | Python paths containing [Bootstrap](../syntax/bootstrap.md) definitions    |
+| tooldefs             |                  |                        | Python paths containing [Tool](../syntax/tools.md) definitions             |
 
 !!!note
 

--- a/docs/config/caching.md
+++ b/docs/config/caching.md
@@ -37,13 +37,13 @@ in contrast to those which are only dependencies of targetted transforms.
 
 The fields of the `!Cache` tag are:
 
-| Field           | Required         | Default | Description                                                        |
-|-----------------|:----------------:|-------- |--------------------------------------------------------------------|
-| path            | :material-check: |         | The python import path to the cache implementation<sup>2</sup>     |
-| max_size        |                  | `None`  | The maximum cache size, which the cache will self-prune down to    |
-| store_condition |                  | `False` | The condition for storing to the cache<sup>3</sup>                 |
-| fetch_condition |                  | `False` | The condition for fetching from the cache<sup>3</sup>              |
-| check_only      |                  | `False` | A list of !Cache configurations (see below)                        |
+| Field             | Required         | Default | Description                                                     |
+|-------------------|:----------------:|-------- |-----------------------------------------------------------------|
+| path              | :material-check: |         | The python import path to the cache implementation<sup>2</sup>  |
+| max_size          |                  | `None`  | The maximum cache size, which the cache will self-prune down to |
+| store_condition   |                  | `False` | The condition for storing to the cache<sup>3</sup>              |
+| fetch_condition   |                  | `False` | The condition for fetching from the cache<sup>3</sup>           |
+| check_determinism |                  | `True`  | Whether to check object determinism<sup>4</sup>                 |
 
 <sup>2</sup> Specified as `<package>.<sub-package>.<class-name>`
 
@@ -61,3 +61,9 @@ The fields of the `!Cache` tag are:
 
     Note: The rate-specification may be removed in the future, in favour of a
     dynamic scheme.
+
+<sup>4</sup> When enabled, if a transform hash exists in the cache and the
+  transform is re-run, check that both produced the same output hashes. It is
+  recommended this is left on, but it may be desirable to turn this off if
+  cache lookups are expensive for a particular cache. Note, this will result
+  in fetches of the key-data even when fetch_condition is `False`.

--- a/docs/config/caching.md
+++ b/docs/config/caching.md
@@ -1,0 +1,63 @@
+Caching is configured through `.yaml` files. The `.bw.yaml`
+(see [bw_yaml](../config/bw_yaml.md)) defines the default caching configuration
+but this can be overriden on the command line with the `--cache-config` option.
+
+Each caching configuration must use a `!Caching` tag as its root element, as
+per the example below:
+
+```yaml linenums="1"
+!Caching
+enabled: True
+targets: False
+caches:
+- !Cache
+  path: infra.caches.Local
+  fetch_condition: True
+  store_condition: True
+  max_size: 5GB
+- !Cache
+  path: infra.caches.FileStore
+  fetch_condition: 10 MB/s
+  store_condition: False
+
+```
+
+The fields of the `!Caching` tag are:
+
+| Field                | Default | Description                                                        |
+|----------------------|-------- |--------------------------------------------------------------------|
+| enabled              | `True`  | Whether to enable caching by default (overridable on command line) |
+| targets              | `False` | Whether to pull targetted<sup>1</sup> transforms from the cache    |
+| caches               | `[]`    | A list of `!Cache` configurations (see below)                      |
+
+
+<sup>1</sup> Targetted transforms are those selected to be run by a workflow,
+in contrast to those which are only dependencies of targetted transforms.
+
+
+The fields of the `!Cache` tag are:
+
+| Field           | Required         | Default | Description                                                        |
+|-----------------|:----------------:|-------- |--------------------------------------------------------------------|
+| path            | :material-check: |         | The python import path to the cache implementation<sup>2</sup>     |
+| max_size        |                  | `None`  | The maximum cache size, which the cache will self-prune down to    |
+| store_condition |                  | `False` | The condition for storing to the cache<sup>3</sup>                 |
+| fetch_condition |                  | `False` | The condition for fetching from the cache<sup>3</sup>              |
+| check_only      |                  | `False` | A list of !Cache configurations (see below)                        |
+
+<sup>2</sup> Specified as `<package>.<sub-package>.<class-name>`
+
+<sup>3</sup> Specified as:
+
+ - `True`: Always store-to or fetch-from this cache
+ - `False`: Never store-to or fetch-from this cache
+ - `<x>B/s`: Only store-to or fetch-from this cache if the transforms byte-rate
+  is below the provided value. This is useful when a cache is networked, and it
+  may be more efficient to just re-compute quick-to-run, high-output transforms
+  than pull them down. Some example values are:
+    - `1B/s`: > 1 second to create each byte.
+    - `1GB/h`: > 1 hour to create each Gigabyte.
+    - `5MB/4m` > 4 minutes to create each 5 Megabytes.
+
+    Note: The rate-specification may be removed in the future, in favour of a
+    dynamic scheme.

--- a/docs/config/caching.md
+++ b/docs/config/caching.md
@@ -9,6 +9,7 @@ per the example below:
 !Caching
 enabled: True
 targets: False
+trace: False
 caches:
 - !Cache
   name: local-cache
@@ -30,6 +31,7 @@ The fields of the `!Caching` tag are:
 |----------------------|-------- |--------------------------------------------------------------------|
 | enabled              | `True`  | Whether to enable caching by default (overridable on command line) |
 | targets              | `False` | Whether to pull targetted<sup>1</sup> transforms from the cache    |
+| trace                | `False` | Whether to enable (computationally intensive) debug tracing.       |
 | caches               | `[]`    | A list of `!Cache` configurations (see below)                      |
 
 

--- a/docs/config/caching.md
+++ b/docs/config/caching.md
@@ -11,11 +11,13 @@ enabled: True
 targets: False
 caches:
 - !Cache
+  name: local-cache
   path: infra.caches.Local
   fetch_condition: True
   store_condition: True
   max_size: 5GB
 - !Cache
+  name: remote-cache
   path: infra.caches.FileStore
   fetch_condition: 10 MB/s
   store_condition: False
@@ -39,6 +41,7 @@ The fields of the `!Cache` tag are:
 
 | Field             | Required         | Default | Description                                                     |
 |-------------------|:----------------:|-------- |-----------------------------------------------------------------|
+| name              | :material-check: |         | The name of the cache (used in logging etc)                     |
 | path              | :material-check: |         | The python import path to the cache implementation<sup>2</sup>  |
 | max_size          |                  | `None`  | The maximum cache size, which the cache will self-prune down to |
 | store_condition   |                  | `False` | The condition for storing to the cache<sup>3</sup>              |

--- a/docs/tech/caching.md
+++ b/docs/tech/caching.md
@@ -1,0 +1,147 @@
+Caching allows build outputs to be re-used across workflow runs. In Blockwork
+caching is used to:
+
+ - Save compute: Builds don't need to be repeated
+ - Save disk-space: Identical objects can be de-duplicated
+ - Save developer-time: Re-building only changed items
+ - Ensure build determinism: Checking the same inputs always produce the same
+    output
+
+See [Caching](../config/caching.md) for details on how to configure caches, or
+read on for details on how to implement your own Blockwork caches, or how the
+caching scheme works.
+
+## Implementing a Cache
+
+A custom cache can be implemented by inheriting from the base Cache class and
+implementing a minimal set of methods. A minimal implementation which stores
+into a local directory is:
+
+```python
+from collections.abc import Iterable
+from filelock import FileLock
+from pathlib import Path
+from shutil import copy, copytree
+
+from blockwork.build.caching import Cache
+from blockwork.config import CacheConfig
+from blockwork.context import Context
+
+
+class BasicFileCache(Cache):
+    def __init__(self, ctx: Context, cfg: CacheConfig) -> None:
+        super().__init__(ctx, cfg) # Super must be called!
+        self.cache_root: Path = ctx.host_scratch / "my-cache"
+        self.cache_root.mkdir(exist_ok=True)
+        self.lock = FileLock(self.cache_root.with_suffix(".lock"))
+
+    def store_item(self, key: str, frm: Path) -> bool:
+        with self.lock:
+            to = self.cache_root / key
+            if to.exists():
+                # Two different key hashes resulted in the same content hash,
+                # item has already been stored
+                return True
+            to.parent.mkdir(exist_ok=True, parents=True)
+            if frm.is_dir():
+                copytree(frm, to)
+            else:
+                copy(frm, to)
+        return True
+
+    def fetch_item(self, key: str, to: Path) -> bool:
+        to.parent.mkdir(exist_ok=True, parents=True)
+        frm = self.cache_root / key
+        if not frm.exists():
+            return False
+        try:
+            to.symlink_to(frm, target_is_directory=frm.is_dir())
+        except FileNotFoundError:
+            return False
+        return True
+```
+
+This implementation will give you a local cache which is safe for running in
+parallel (the lock could be removed if only running serially).
+
+However, without implementing some of the optional methods this cache will grow
+indefinitely. To allow the cache to self prune, some extra methods must be
+implemented:
+
+```python
+    def drop_item(self, key: str) -> bool:
+        with self.lock:
+            path = self.cache_root / key
+            if path.exists():
+                if path.is_dir():
+                    rmtree(path)
+                else:
+                    path.unlink()
+        return True
+
+    def iter_keys(self) -> Iterable[str]:
+        if not self.cache_root.exists():
+            yield from []
+        yield from self.cache_root.iterdir()
+```
+
+This allows the cache to prune itself down to the maximum size as expressed in
+the cache configuration. It will prune itself at the end of each workflow
+by calculating a score for each item based on `time-to-create / size` and
+removing items from lowest to highest score until the max-size is reached.
+
+A final enhancement enables intelligent pruning based on how recently an item
+was used by including a `time-since-last-use` term. This can be enabled by
+implementing a final pair of methods as follows:
+
+```python
+    def get_last_fetch_utc(self, key: str) -> float:
+        frm = self.cache_root / key
+        try:
+            return frm.stat().st_mtime
+        except OSError:
+            return 0
+
+    def set_last_fetch_utc(self, key: str):
+        frm = self.cache_root / key
+        if frm.exists():
+            frm.touch(exist_ok=True)
+```
+
+## Caching Scheme
+
+Blockwork's cache scheme calculates two types of hash:
+
+ - Transform hashes: Calculated by hashing a transform's definition with the
+    definition of its dependencies recursively. This can be calculated before
+    any transforms have been run.
+ - File hashes: Calculated by hashing a transform file-output, which can only
+    be done after the transform has run.
+
+After a transform is run, the output-files are stored in the cache according
+to thier hash, and a key-file containing each output hash is stored according
+to the transform hash.
+
+This two level scheme allows many transforms to refer to the same cached file,
+preventing unnecessary copies being stored.
+
+### Process
+
+Stages:
+
+  - Initial:
+    - Hash the content of static input interfaces
+    - Use these to compute transform hashkeys for nodes with no dependencies
+    - Use input interface names along with the hashkeys of transforms that
+        output them to get the transform hashkeys for nodes with dependencies
+
+  - Pre-run:
+    - Go through the transforms in reverse order
+    - Try and pull all output interfaces from caches - if successful mark that
+        transform as fetched.
+    - If all dependents of a transform are fetched, mark a transform as skipped
+
+  - During-run:
+    - Go through transforms in dependency order as usual
+    - Skip transforms marked as fetched or skipped
+    - Push output interfaces to all caches that allow it

--- a/docs/tech/caching.md
+++ b/docs/tech/caching.md
@@ -119,7 +119,7 @@ Blockwork's cache scheme calculates two types of hash:
     be done after the transform has run.
 
 After a transform is run, the output-files are stored in the cache according
-to thier hash, and a key-file containing each output hash is stored according
+to their hash, and a key-file containing each output hash is stored according
 to the transform hash.
 
 This two level scheme allows many transforms to refer to the same cached file,

--- a/example/.bw.yaml
+++ b/example/.bw.yaml
@@ -1,6 +1,7 @@
 !Blockwork
 project: example
 site: ./site.yaml
+default_cache_config: ./caches.yaml
 tooldefs:
   - infra.tools.misc
   - infra.tools.compilers

--- a/example/.caches.yaml
+++ b/example/.caches.yaml
@@ -1,0 +1,9 @@
+!Caching
+targets: False
+enabled: True
+caches:
+- !Cache
+  path: infra.caches.BasicFileCache
+  fetch_condition: True
+  store_condition: True
+  max_size: 5GB

--- a/example/.caches.yaml
+++ b/example/.caches.yaml
@@ -3,6 +3,7 @@ targets: False
 enabled: True
 caches:
 - !Cache
+  name: local-cache
   path: infra.caches.BasicFileCache
   fetch_condition: True
   store_condition: True

--- a/example/infra/caches.py
+++ b/example/infra/caches.py
@@ -14,10 +14,6 @@ class BasicFileCache(Cache):
         self.cache_root.mkdir(exist_ok=True)
         self.content_store.mkdir(exist_ok=True)
 
-    @property
-    def target_size(self) -> int:
-        return 1024**3
-
     def store_item(self, key: str, frm: Path) -> bool:
         to = self.content_store / key
         if to.exists():

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,8 +31,8 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 nav:
   - Welcome: "index.md"
   - Foundations: "foundations.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,12 +39,14 @@ nav:
   - Technologies:
     - Containers: "tech/containers.md"
     - State: "tech/state.md"
+    - Caching: "tech/caching.md"
   - Configuration:
     - ".bw.yaml": "config/bw_yaml.md"
+    - "caching": "config/caching.md"
   - Syntax:
     - Bootstrap: "syntax/bootstrap.md"
     - Tools: "syntax/tools.md"
-    - Tools: "syntax/transforms.md"
+    - Transforms: "syntax/transforms.md"
   - "Command Line Interface":
     - Introduction: "cli/introduction.md"
     - bootstrap: "cli/bootstrap.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ ordered-set = "4.1.0"
 filelock = "3.14.0"
 pytz = "2024.1"
 requests = "2.31.0"
-gator-eda = { git = "https://github.com/Intuity/gator.git", rev = "247179a700dbfe1b7854b57be8cebfcad282e5d9" }
+gator-eda = { git = "https://github.com/Intuity/gator.git", rev = "e562e77180b31ac620451b0b492ccb366e125496" }
 boto3 = "1.34.103"
 humanfriendly = "^10.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ ordered-set = "4.1.0"
 filelock = "3.14.0"
 pytz = "2024.1"
 requests = "2.31.0"
-gator-eda = { git = "https://github.com/Intuity/gator.git", rev = "e562e77180b31ac620451b0b492ccb366e125496" }
+gator-eda = { git = "https://github.com/Intuity/gator.git", rev = "feb406d432395aee74945a91316eccf3002b8e6d" }
 boto3 = "1.34.103"
 humanfriendly = "^10.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ ordered-set = "4.1.0"
 filelock = "3.14.0"
 pytz = "2024.1"
 requests = "2.31.0"
-gator-eda = { git = "https://github.com/Intuity/gator.git", rev = "abcf68dfc920fc56ae189541f4b607bdf7136468" }
+gator-eda = { git = "https://github.com/Intuity/gator.git", rev = "247179a700dbfe1b7854b57be8cebfcad282e5d9" }
 boto3 = "1.34.103"
 humanfriendly = "^10.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["poetry"]
-build-backend = "poetry.masonry.api"
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "blockwork"
@@ -24,6 +24,7 @@ pytz = "2024.1"
 requests = "2.31.0"
 gator-eda = { git = "https://github.com/Intuity/gator.git", rev = "abcf68dfc920fc56ae189541f4b607bdf7136468" }
 boto3 = "1.34.103"
+humanfriendly = "^10.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "7.3.1"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -39,13 +39,7 @@ class TestContext:
             )
         # Create a configuration file
         with bw_yaml.open("w", encoding="utf-8") as fh:
-            fh.write(
-                "!Blockwork\n"
-                "project: test_project\n"
-                "root: /a/b\n"
-                "tooldefs:\n"
-                "  - infra.tools\n"
-            )
+            fh.write("!Blockwork\nproject: test_project\nroot: /a/b\ntooldefs:\n  - infra.tools\n")
         # Create a context
         ctx = Context(root)
         assert ctx.host_root == root
@@ -55,7 +49,7 @@ class TestContext:
         assert ctx.host_state.exists()
         assert ctx.container_root == Path("/a/b")
         assert ctx.container_scratch == Path("/scratch")
-        assert ctx.file == ".bw.yaml"
+        assert ctx.file == Path(".bw.yaml")
         assert ctx.config_path == bw_yaml
         assert isinstance(ctx.config, Blockwork)
         assert ctx.config.project == "test_project"
@@ -75,20 +69,14 @@ class TestContext:
             )
         # Create a configuration file
         with bw_yaml.open("w", encoding="utf-8") as fh:
-            fh.write(
-                "!Blockwork\n"
-                "project: test_project\n"
-                "root: /a/b\n"
-                "tooldefs:\n"
-                "  - infra.tools\n"
-            )
+            fh.write("!Blockwork\nproject: test_project\nroot: /a/b\ntooldefs:\n  - infra.tools\n")
         # Create a context in a sub-path
         sub_path = tmp_path / "a" / "b" / "c"
         sub_path.mkdir(parents=True)
         ctx = Context(sub_path)
         assert ctx.host_root == tmp_path
         assert ctx.container_root == Path("/a/b")
-        assert ctx.file == ".bw.yaml"
+        assert ctx.file == Path(".bw.yaml")
         assert ctx.config_path == bw_yaml
         assert isinstance(ctx.config, Blockwork)
         assert ctx.config.project == "test_project"

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -112,7 +112,7 @@ def match_results(results, run, stored, fetched, skipped):
 class TestWorkFlowDeps:
     class DummyTransform(Transform):
         def run(self, *args, **kwargs):
-            return SimpleNamespace(run_time=1, exit_code=0)
+            return SimpleNamespace(run_time=1, exit_code=0, interacted=False)
 
     class TFAutoA(DummyTransform):
         test_ip: Path = Transform.IN()

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 import pytest
 
 from blockwork.build.caching import Cache
+from blockwork.config import CacheConfig
 from blockwork.config.api import ConfigApi
 from blockwork.config.base import Config
 from blockwork.tools import Invocation, tools
@@ -19,6 +20,7 @@ class DummyCache(Cache):
     """
 
     def __init__(self):
+        self.cfg = CacheConfig(path="")
         self.content_store = {}
 
     @property
@@ -43,6 +45,9 @@ class DummyCache(Cache):
 
     def get_last_fetch_utc(self, key: str) -> float:
         return 0
+
+    def set_last_fetch_utc(self, key: str):
+        return None
 
     def iter_keys(self) -> Iterable[str]:
         yield from list(self.content_store.keys())

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -280,6 +280,7 @@ class TestWorkFlowDeps:
             host_scratch = tmp_path
             caches: ClassVar[list[Cache]] = [DummyCache()]
             cache_targets = False
+            cache_expect = False
 
         TransformA, TransformB = self.TFAutoA, self.TFAutoB  # noqa N806
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -20,7 +20,7 @@ class DummyCache(Cache):
     """
 
     def __init__(self):
-        self.cfg = CacheConfig(path="")
+        self.cfg = CacheConfig(path="", name="dummy")
         self.content_store = {}
 
     @property

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -279,7 +279,7 @@ class TestWorkFlowDeps:
             host_root = tmp_path
             host_scratch = tmp_path
             caches: ClassVar[list[Cache]] = [DummyCache()]
-            caching_forced = False
+            cache_targets = False
 
         TransformA, TransformB = self.TFAutoA, self.TFAutoB  # noqa N806
 


### PR DESCRIPTION
Added the ability to configure caches through a configuration file.

Improved cache behaviour when multiple caches are present and now allow configuration of which caches are active. Added determinism checking for when objects have the same transform hash but different output hashes.

Added documentation on caches.

Documented further improvements in #136